### PR TITLE
update to grocy v1.24.0

### DIFF
--- a/Dockerfile-grocy
+++ b/Dockerfile-grocy
@@ -1,8 +1,8 @@
 FROM php:7.2-fpm-alpine
 MAINTAINER Talmai Oliveira <to@talm.ai>
 
-ENV REFRESHED_AT  2018-12-23
-ENV GROCY_VERSION 1.23.1
+ENV REFRESHED_AT  2019-1-1
+ENV GROCY_VERSION 1.24.0
 
 RUN	apk update && \
 	apk upgrade && \

--- a/Dockerfile-grocy
+++ b/Dockerfile-grocy
@@ -1,8 +1,8 @@
 FROM php:7.2-fpm-alpine
 MAINTAINER Talmai Oliveira <to@talm.ai>
 
-ENV REFRESHED_AT  2018-11-15
-ENV GROCY_VERSION 1.22.0
+ENV REFRESHED_AT  2018-12-23
+ENV GROCY_VERSION 1.23.1
 
 RUN	apk update && \
 	apk upgrade && \
@@ -29,7 +29,7 @@ RUN	apk update && \
 	rm -f grocy.zip && \
 	cd grocy-${GROCY_VERSION} && \
 	mv public /www/public && \
-	mv info.php /www/public && \
+#	mv info.php /www/public && \
 	mv controllers /www/controllers && \
 	mv data /www/data && \
 	mv helpers /www/helpers && \

--- a/Dockerfile-grocy
+++ b/Dockerfile-grocy
@@ -29,7 +29,6 @@ RUN	apk update && \
 	rm -f grocy.zip && \
 	cd grocy-${GROCY_VERSION} && \
 	mv public /www/public && \
-#	mv info.php /www/public && \
 	mv controllers /www/controllers && \
 	mv data /www/data && \
 	mv helpers /www/helpers && \


### PR DESCRIPTION
Updates to Grocy Version 1.23.1 . Had to comment out line 32 because "info.php" doesn't exists.