### PR TITLE
Update to v1.24.1 & Language option

### DIFF
--- a/Dockerfile-grocy
+++ b/Dockerfile-grocy
@@ -1,8 +1,8 @@
 FROM php:7.2-fpm-alpine
 MAINTAINER Talmai Oliveira <to@talm.ai>
 
-ENV REFRESHED_AT  2018-11-15
-ENV GROCY_VERSION 1.22.0
+ENV REFRESHED_AT  2019-1-16
+ENV GROCY_VERSION 1.24.1
 
 RUN	apk update && \
 	apk upgrade && \
@@ -29,7 +29,6 @@ RUN	apk update && \
 	rm -f grocy.zip && \
 	cd grocy-${GROCY_VERSION} && \
 	mv public /www/public && \
-	mv info.php /www/public && \
 	mv controllers /www/controllers && \
 	mv data /www/data && \
 	mv helpers /www/helpers && \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,7 @@ services:
       MAX_UPLOAD:          50M
       PHP_MAX_FILE_UPLOAD: 200
       PHP_MAX_POST:        100M
+      GROCY_CULTURE: en
     container_name: grocy
 volumes:
   database:


### PR DESCRIPTION
Updates to Grocy v1.24.1 and adds a language option to the docker-compose.yml. With just 2 commits this time. line 32 mv info.php is removed also.