### PR TITLE
FIX: Broken composer installer

### DIFF
--- a/Dockerfile-grocy
+++ b/Dockerfile-grocy
@@ -21,7 +21,7 @@ RUN	apk update && \
 #    sed -i "s|;*max_file_uploads =.*|max_file_uploads = ${PHP_MAX_FILE_UPLOAD}|i" /usr/local/etc/php.ini && \
 #    sed -i "s|;*post_max_size =.*|post_max_size = ${PHP_MAX_POST}|i" /usr/local/etc/php.ini && \
 #    sed -i "s|;*cgi.fix_pathinfo=.*|cgi.fix_pathinfo= 0|i" /usr/local/etc/php.ini && \
-	wget https://raw.githubusercontent.com/composer/getcomposer.org/1b137f8bf6db3e79a38a5bc45324414a6b1f9df2/web/installer -O - -q | php -- --quiet && \
+	wget https://raw.githubusercontent.com/composer/getcomposer.org/76a7060ccb93902cd7576b67264ad91c8a2700e2/web/installer -O - -q | php -- --quiet && \
 	mkdir -p /tmp/download && \
 	cd /tmp/download && \
 	wget -t 3 -T 30 -nv -O "grocy.zip" "https://github.com/grocy/grocy/archive/v${GROCY_VERSION}.zip" && \


### PR DESCRIPTION
There seems to be a broken composer installer in the dockerfile. I changed it to the one mentioned in the [instructions](https://getcomposer.org/doc/faqs/how-to-install-composer-programmatically.md).

I don't know for sure if there are any compatibility issues when using another composer version, since I am not using composer myself.

fixes #12