### PR TITLE
Fixes 404/500 errors when uploading files.

### DIFF
--- a/Dockerfile-grocy-nginx
+++ b/Dockerfile-grocy-nginx
@@ -17,6 +17,9 @@ RUN	apk update && \
 		-subj /CN=localhost && \
 	rm -rf /var/cache/apk/*
 
+# Make "nobody" user the owner of tmp folder
+RUN chown nobody /var/tmp/nginx
+
 COPY docker_nginx/nginx.conf /etc/nginx/nginx.conf
 COPY docker_nginx/common.conf /etc/nginx/common.conf
 COPY docker_nginx/conf.d/default.conf /etc/nginx/conf.d/default.conf


### PR DESCRIPTION
Fixes #15 by causing the temporary folder used by nginx to be owned by the nobody user.