### PR TITLE
nginx build fix

### DIFF
--- a/Dockerfile-grocy-nginx
+++ b/Dockerfile-grocy-nginx
@@ -15,7 +15,8 @@ RUN     apk update && \
                 -days 365 \
                 -nodes \
                 -subj /CN=localhost && \
-        chown nobody /var/tmp/nginx && \
+	mkdir -p /var/tmp/nginx && \
+	chown nobody /var/tmp/nginx && \
         rm -rf /var/cache/apk/*
 
 COPY docker_nginx/nginx.conf /etc/nginx/nginx.conf

--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ Note: if you have not pulled any of the images from the repository, when you do 
 ### To pull the latest images to your machine:
 
 ```
-docker pull grocy/grocy-docker:nginx
-docker pull grocy/grocy-docker:grocy
+docker pull sobriquet/grocy-docker:nginx
+docker pull sobriquet/grocy-docker:grocy
 ```
 
 Or just `docker-compose pull`.


### PR DESCRIPTION
Couldn't get nginx to build, as it couldn't chown the /var/tmp folder that didn't exist.