### PR TITLE
Remove dependency on 'lastversion' package

### DIFF
--- a/Dockerfile-grocy
+++ b/Dockerfile-grocy
@@ -42,7 +42,7 @@ RUN     set -o pipefail && \
         wget --header "Authorization: ${GITHUB_API_TOKEN}" -t 3 -T 30 -nv "https://github.com/grocy/grocy/releases/latest/download/grocy.tar.gz" && \
         tar xzf grocy.tar.gz && \
         rm grocy.tar.gz && \
-        mv grocy/* . && \
+        mv grocy-*/* . && \
         rm -r grocy-* && \
         mkdir data/viewcache && \
         cp config-dist.php data/config.php && \

--- a/Dockerfile-grocy
+++ b/Dockerfile-grocy
@@ -18,12 +18,11 @@ RUN     apk update && \
         sed -i "s|;*listen\s*=\s*/||g" /usr/local/etc/php-fpm.conf && \
         sed -i "s|;*chdir\s*=\s*/var/www|chdir = /www|g" /usr/local/etc/php-fpm.d/www.conf && \
         wget https://getcomposer.org/installer -O - -q | php -- --quiet && \
-        pip install lastversion==0.2.4 && \
         mkdir -p /tmp/download && \
-        wget -t 3 -T 30 -nv -O "grocy.tar.gz" $(lastversion --source grocy/grocy) && \
+        wget -t 3 -T 30 -nv "https://github.com/grocy/grocy/releases/latest/download/grocy.tar.gz" && \
         tar xzf grocy.tar.gz && \
         rm -f grocy.tar.gz && \
-        cd grocy-* && \
+        cd grocy && \
         mv public /www/public && \
         mv controllers /www/controllers && \
         mv data /www/data && \

--- a/Dockerfile-grocy
+++ b/Dockerfile-grocy
@@ -1,6 +1,8 @@
 FROM php:7.2-fpm-alpine
 LABEL maintainer="Talmai Oliveira <to@talm.ai>"
 
+ARG GROCY_VERSION=v2.6.1
+
 # Optionally authenticate with GitHub using an API token
 #
 # This can reduce instances of download rate limiting by GitHub
@@ -39,9 +41,9 @@ RUN     apk update && \
 
 # Extract application release package
 RUN     set -o pipefail && \
-        wget --header "Authorization: ${GITHUB_API_TOKEN}" -t 3 -T 30 -nv "https://github.com/grocy/grocy/releases/latest/download/grocy.tar.gz" && \
-        tar xzf grocy.tar.gz && \
-        rm grocy.tar.gz && \
+        wget --header "Authorization: ${GITHUB_API_TOKEN}" -t 3 -T 30 -nv "https://github.com/grocy/grocy/archive/${GROCY_VERSION}.tar.gz" && \
+        tar xzf "${GROCY_VERSION}.tar.gz" && \
+        rm "${GROCY_VERSION}.tar.gz" && \
         mv grocy-*/* . && \
         rm -r grocy-* && \
         mkdir data/viewcache && \


### PR DESCRIPTION
~~This changeset relies on hypothetical release asset filename updates proposed by https://github.com/grocy/grocy/pull/641~~

Remove the dependency on `lastversion`, and allow the user to specify a `grocy` [release version](https://github.com/grocy/grocy/releases) at build-time.