### PR TITLE
Support optional authentication via GitHub API token

### DIFF
--- a/Dockerfile-grocy
+++ b/Dockerfile-grocy
@@ -58,7 +58,8 @@ RUN     apk update && \
 
 # run php composer.phar with -vvv for extra debug information
 RUN cd /var/www/html && \
-        COMPOSER_AUTH="{\"github-oauth\": {\"github.com\": \"${GITHUB_API_TOKEN}\"}}" php composer.phar --working-dir=/www/ -n install && \
+        COMPOSER_OAUTH=${GITHUB_API_TOKEN:+"\"github.com\": \"${GITHUB_API_TOKEN}\""} && \
+        COMPOSER_AUTH="{\"github-oauth\": { ${COMPOSER_OAUTH} }}" php composer.phar --working-dir=/www/ -n install && \
         cp /www/config-dist.php /www/data/config.php && \
         cd /www && \
         yarn install && \

--- a/Dockerfile-grocy
+++ b/Dockerfile-grocy
@@ -58,7 +58,7 @@ RUN     apk update && \
 
 # run php composer.phar with -vvv for extra debug information
 RUN cd /var/www/html && \
-        php composer.phar --working-dir=/www/ -n install && \
+        COMPOSER_AUTH="{\"github-oauth\": {\"github.com\": \"${GITHUB_API_TOKEN}\"}}" php composer.phar --working-dir=/www/ -n install && \
         cp /www/config-dist.php /www/data/config.php && \
         cd /www && \
         yarn install && \

--- a/Dockerfile-grocy
+++ b/Dockerfile-grocy
@@ -31,7 +31,7 @@ RUN     apk update && \
         wget https://getcomposer.org/installer -O - -q | php -- --quiet && \
         pip install lastversion==0.2.4 && \
         mkdir -p /tmp/download && \
-        wget -t 3 -T 30 -nv -O "grocy.tar.gz" $(GITHUB_API_TOKEN=${GITHUB_API_TOKEN} lastversion --source grocy/grocy) && \
+        wget --header "Authorization: ${GITHUB_API_TOKEN}" -t 3 -T 30 -nv -O "grocy.tar.gz" $(GITHUB_API_TOKEN=${GITHUB_API_TOKEN} lastversion --source grocy/grocy) && \
         tar xzf grocy.tar.gz && \
         rm -f grocy.tar.gz && \
         cd grocy-* && \

--- a/Dockerfile-grocy
+++ b/Dockerfile-grocy
@@ -1,6 +1,17 @@
 FROM php:7.2-fpm-alpine
 LABEL maintainer="Talmai Oliveira <to@talm.ai>"
 
+# Optionally authenticate with GitHub using an API token
+#
+# This can reduce instances of download rate limiting by GitHub
+# https://developer.github.com/v3/#rate-limiting
+#
+# This value is *not* assigned to a variable using the ENV instruction,
+# since those variables are persisted in the resulting image and could leak
+# developer credentials
+# https://docs.docker.com/engine/reference/builder/#env
+ARG GITHUB_API_TOKEN
+
 RUN     apk update && \
         apk upgrade && \
         apk add --no-cache --update yarn git python py-pip wget freetype libpng libjpeg-turbo freetype-dev libpng-dev libjpeg-turbo-dev && \
@@ -20,7 +31,7 @@ RUN     apk update && \
         wget https://getcomposer.org/installer -O - -q | php -- --quiet && \
         pip install lastversion==0.2.4 && \
         mkdir -p /tmp/download && \
-        wget -t 3 -T 30 -nv -O "grocy.tar.gz" $(lastversion --source grocy/grocy) && \
+        wget -t 3 -T 30 -nv -O "grocy.tar.gz" $(GITHUB_API_TOKEN=${GITHUB_API_TOKEN} lastversion --source grocy/grocy) && \
         tar xzf grocy.tar.gz && \
         rm -f grocy.tar.gz && \
         cd grocy-* && \


### PR DESCRIPTION
During builds of `grocy-docker`, the `lastversion` utility makes requests to the GitHub API.

This can cause build-time failures if GitHub chooses to rate-limit those requests, which are unauthenticated by default.

`lastversion==0.24` does [support authorization](https://github.com/dvershinin/lastversion/blob/v0.2.4/lastversion/lastversion.py#L177-L179) via a `GITHUB_API_TOKEN` environment variable.

This changeset adds support for a `Dockerfile-grocy` [build-argument](https://docs.docker.com/engine/reference/builder/#arg) which allows a GitHub API key to be specified at build-time.

If present the API token is also passed to `composer` for use retrieving vendor packages hosted on GitHub.

Care is taken to avoid persisting this API key inside the resulting image.