### PR TITLE
Place 'apk install' packages onto separate lines

### DIFF
--- a/Dockerfile-grocy
+++ b/Dockerfile-grocy
@@ -3,7 +3,18 @@ LABEL maintainer="Talmai Oliveira <to@talm.ai>"
 
 RUN     apk update && \
         apk upgrade && \
-        apk add --no-cache --update yarn git python py-pip wget freetype libpng libjpeg-turbo freetype-dev libpng-dev libjpeg-turbo-dev && \
+        apk add --no-cache --update \
+            yarn \
+            git \
+            python \
+            py-pip \
+            wget \
+            freetype \
+            libpng \
+            libjpeg-turbo \
+            freetype-dev \
+            libpng-dev \
+            libjpeg-turbo-dev && \
         docker-php-ext-configure gd \
             --with-gd \
             --with-freetype-dir=/usr/include/ \

--- a/Dockerfile-grocy-nginx
+++ b/Dockerfile-grocy-nginx
@@ -3,7 +3,9 @@ MAINTAINER Talmai Oliveira <to@talm.ai>
 
 RUN     apk update && \
         apk upgrade && \
-        apk add --update openssl nginx && \
+        apk add --update \
+            openssl \
+            nginx && \
         mkdir -p /etc/nginx/certificates && \
         mkdir -p /var/run/nginx && \
         mkdir -p /usr/share/nginx/html && \


### PR DESCRIPTION
Following the [Best practices for writing Dockerfiles](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#run), we can make the `apk install` step a little easier to read (especially when changes/diffs occur) by placing each package on a separate line.