### PR TITLE
Introduce consistent apk update patterns in Dockerfiles

### DIFF
--- a/Dockerfile-grocy
+++ b/Dockerfile-grocy
@@ -3,7 +3,7 @@ LABEL maintainer="Talmai Oliveira <to@talm.ai>"
 
 RUN     apk update && \
         apk upgrade && \
-        apk add --no-cache --update \
+        apk add --no-cache \
             yarn \
             git \
             python \

--- a/Dockerfile-grocy
+++ b/Dockerfile-grocy
@@ -2,7 +2,6 @@ FROM php:7.2-fpm-alpine
 LABEL maintainer="Talmai Oliveira <to@talm.ai>"
 
 RUN     apk update && \
-        apk upgrade && \
         apk add --no-cache \
             yarn \
             git \

--- a/Dockerfile-grocy-nginx
+++ b/Dockerfile-grocy-nginx
@@ -2,7 +2,7 @@ FROM alpine:latest
 MAINTAINER Talmai Oliveira <to@talm.ai>
 
 RUN     apk update && \
-        apk add \
+        apk add --no-cache \
             openssl \
             nginx && \
         mkdir -p /etc/nginx/certificates && \

--- a/Dockerfile-grocy-nginx
+++ b/Dockerfile-grocy-nginx
@@ -3,7 +3,7 @@ MAINTAINER Talmai Oliveira <to@talm.ai>
 
 RUN     apk update && \
         apk upgrade && \
-        apk add --update \
+        apk add \
             openssl \
             nginx && \
         mkdir -p /etc/nginx/certificates && \

--- a/Dockerfile-grocy-nginx
+++ b/Dockerfile-grocy-nginx
@@ -2,7 +2,6 @@ FROM alpine:latest
 MAINTAINER Talmai Oliveira <to@talm.ai>
 
 RUN     apk update && \
-        apk upgrade && \
         apk add \
             openssl \
             nginx && \


### PR DESCRIPTION
Running package management `upgrade` operations is not recommended per [Dockerfile authoring best practices](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#run); this changeset follows that guidance, removes some redundant `update` steps in `Dockerfile-grocy` and `Dockerfile-grocy-nginx`, and ensures that the `--no-cache` flag is specified consistently when packages are added.