### PR TITLE
Use Alpine package-managed installation of 'composer'

### DIFF
--- a/Dockerfile-grocy
+++ b/Dockerfile-grocy
@@ -58,7 +58,7 @@ RUN     apk update && \
 
 # run php composer.phar with -vvv for extra debug information
 RUN cd /var/www/html && \
-        php composer.phar --working-dir=/www/ -n install && \
+        composer --working-dir=/www/ -n install && \
         cp /www/config-dist.php /www/data/config.php && \
         cd /www && \
         yarn install && \

--- a/Dockerfile-grocy
+++ b/Dockerfile-grocy
@@ -58,7 +58,7 @@ RUN     apk update && \
 
 # run php composer.phar with -vvv for extra debug information
 RUN cd /var/www/html && \
-        composer --working-dir=/www/ -n install && \
+        composer install --no-interaction --working-dir=/www/ && \
         cp /www/config-dist.php /www/data/config.php && \
         cd /www && \
         yarn install && \

--- a/Dockerfile-grocy
+++ b/Dockerfile-grocy
@@ -45,10 +45,10 @@ RUN     apk update && \
         mv publication_assets/ /www/publication_assets && \
         mv services/ /www/services && \
         mv views/ /www/views && \
+        mv composer.* /root/.composer/ && \
         mv .yarnrc /www/ && \
         mv *.php /www/ && \
         mv *.json /www/ && \
-        mv composer.* /root/.composer/ && \
         mv *yarn* /www/ && \
         mv *.sh /www/ && \
     # Cleaning up

--- a/Dockerfile-grocy
+++ b/Dockerfile-grocy
@@ -45,7 +45,7 @@ RUN     apk update && \
         mv publication_assets/ /www/publication_assets && \
         mv services/ /www/services && \
         mv views/ /www/views && \
-        mv composer.* /root/.composer/ && \
+        mv composer.* /www/ && \
         mv .yarnrc /www/ && \
         mv *.php /www/ && \
         mv *.json /www/ && \

--- a/Dockerfile-grocy
+++ b/Dockerfile-grocy
@@ -56,7 +56,6 @@ RUN     apk update && \
         rm -rf /var/cache/apk/*
 
 
-# run php composer.phar with -vvv for extra debug information
 RUN cd /var/www/html && \
         composer install --no-interaction --working-dir=/www/ && \
         cp /www/config-dist.php /www/data/config.php && \

--- a/Dockerfile-grocy
+++ b/Dockerfile-grocy
@@ -4,6 +4,7 @@ LABEL maintainer="Talmai Oliveira <to@talm.ai>"
 RUN     apk update && \
         apk upgrade && \
         apk add --no-cache --update \
+            composer \
             yarn \
             git \
             python \
@@ -28,7 +29,6 @@ RUN     apk update && \
         sed -i "s|;*listen\s*=\s*127.0.0.1:9000|listen = 9000|g" /usr/local/etc/php-fpm.conf && \
         sed -i "s|;*listen\s*=\s*/||g" /usr/local/etc/php-fpm.conf && \
         sed -i "s|;*chdir\s*=\s*/var/www|chdir = /www|g" /usr/local/etc/php-fpm.d/www.conf && \
-        wget https://getcomposer.org/installer -O - -q | php -- --quiet && \
         pip install lastversion==0.2.4 && \
         mkdir -p /tmp/download && \
         wget -t 3 -T 30 -nv -O "grocy.tar.gz" $(lastversion --source grocy/grocy) && \


### PR DESCRIPTION
At the time of writing, the `composer` PHP dependency management tool that is installed during the `Dockerfile-grocy` build is being [retrieved](https://github.com/grocy/grocy-docker/blob/ab103bac5b7fac57047df54590d752760d3d5c88/Dockerfile-grocy#L41) via a build-time download.

The current version available from [getcomposer.org](https://getcomposer.org/download/) is v1.10.1.

Although this is a little behind the latest Alpine Linux (v3.11) [apk-distributed release of `composer`](https://pkgs.alpinelinux.org/packages?name=composer&branch=v3.11) (v1.9.1-r0), we're not relying on any recent functionality from `composer`, and so the binary and command-line arguments are compatible.