### PR TITLE
Remove unused temporary directory references

### DIFF
--- a/Dockerfile-grocy
+++ b/Dockerfile-grocy
@@ -19,7 +19,6 @@ RUN     apk update && \
         sed -i "s|;*chdir\s*=\s*/var/www|chdir = /www|g" /usr/local/etc/php-fpm.d/www.conf && \
         wget https://getcomposer.org/installer -O - -q | php -- --quiet && \
         pip install lastversion==0.2.4 && \
-        mkdir -p /tmp/download && \
         wget -t 3 -T 30 -nv -O "grocy.tar.gz" $(lastversion --source grocy/grocy) && \
         tar xzf grocy.tar.gz && \
         rm -f grocy.tar.gz && \
@@ -41,7 +40,6 @@ RUN     apk update && \
         mv *yarn* /www/ && \
         mv *.sh /www/ && \
     # Cleaning up
-        rm -rf /tmp/download && \
         rm -rf /var/cache/apk/*
 
 


### PR DESCRIPTION
This change removes a temporary directory that is created and removed but otherwise unused during the `Dockerfile-grocy` build process.