### PR TITLE
Productionize dependency installation

### DIFF
--- a/Dockerfile-grocy
+++ b/Dockerfile-grocy
@@ -64,7 +64,7 @@ RUN     apk update && \
 
 RUN cd /var/www/html && \
         COMPOSER_OAUTH=${GITHUB_API_TOKEN:+"\"github.com\": \"${GITHUB_API_TOKEN}\""} && \
-        COMPOSER_AUTH="{\"github-oauth\": { ${COMPOSER_OAUTH} }}" composer install --no-interaction --no-dev --optimize-autoloader --working-dir=/www/ \
+        COMPOSER_AUTH="{\"github-oauth\": { ${COMPOSER_OAUTH} }}" composer install --no-interaction --no-dev --optimize-autoloader --working-dir=/www/ && \
         cp /www/config-dist.php /www/data/config.php && \
         cd /www && \
         yarn install --production && \

--- a/Dockerfile-grocy
+++ b/Dockerfile-grocy
@@ -57,10 +57,10 @@ RUN     apk update && \
 
 
 RUN cd /var/www/html && \
-        composer install --no-interaction --working-dir=/www/ && \
+        composer install --no-interaction --no-dev --optimize-autoloader --working-dir=/www/ && \
         cp /www/config-dist.php /www/data/config.php && \
         cd /www && \
-        yarn install && \
+        yarn install --production && \
         mkdir /www/data/viewcache && \
         chown www-data:www-data -R /www/
 


### PR DESCRIPTION
Although there are not currently any `yarn` `devDependencies` listed in the `grocy` [package.json](https://github.com/grocy/grocy/blob/caf7127c13a90fcb032aae6b7f8ae5e1fbc7fc03/package.json), nor any `composer` `require-dev` dependencies listed in [composer.json](https://github.com/grocy/grocy/blob/caf7127c13a90fcb032aae6b7f8ae5e1fbc7fc03/composer.json), it seems a good idea to introduce productionized dependency installation during image builds from an early stage, to avoid accidental bundling of additional content.

The `--optimize-autoloader` flag is also added for `composer`, and a small fix for a problem introduced during #43 is merged here also.