### PR TITLE
Build OCI-compatible pod images via Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 IMAGE_COMMIT := $(shell git rev-parse --short HEAD)
 
 .grocy:
-	buildah bud -f Dockerfile-grocy -t grocy:${IMAGE_COMMIT} --build-arg GITHUB_API_TOKEN=${GITHUB_API_TOKEN} .
+	buildah bud -f Dockerfile-grocy -t grocy:${IMAGE_COMMIT} --build-arg GITHUB_API_TOKEN=$(echo ${GITHUB_API_TOKEN}) .
 
 .grocy_nginx:
 	buildah bud -f Dockerfile-grocy-nginx -t grocy-nginx:${IMAGE_COMMIT} .

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+IMAGE_COMMIT := $(shell git rev-parse --short HEAD)
+
+.grocy:
+	buildah bud -f Dockerfile-grocy -t grocy:${IMAGE_COMMIT} --build-arg GITHUB_API_TOKEN=${GITHUB_API_TOKEN} .
+
+.grocy_nginx:
+	buildah bud -f Dockerfile-grocy-nginx -t grocy-nginx:${IMAGE_COMMIT} .
+
+pod: .grocy .grocy_nginx
+	podman pod rm -f grocy-pod || true
+	podman pod create --name grocy-pod
+	podman run --read-only --pod grocy-pod -dt --name grocy grocy:${IMAGE_COMMIT}
+	podman run ---read-only -read-only --pod grocy-pod -dt --name grocy-nginx grocy-nginx:${IMAGE_COMMIT}


### PR DESCRIPTION
This change provides the ability to build [opencontainer](https://www.opencontainers.org/)-compatible `grocy` images via `make`.