### PR TITLE
Remove redundant cache clearing

### DIFF
--- a/Dockerfile-grocy
+++ b/Dockerfile-grocy
@@ -57,9 +57,7 @@ RUN     apk update && \
         mv *.php /www/ && \
         mv *.json /www/ && \
         mv *yarn* /www/ && \
-        mv *.sh /www/ && \
-    # Cleaning up
-        rm -rf /var/cache/apk/*
+        mv *.sh /www/
 
 
 RUN cd /var/www/html && \

--- a/Dockerfile-grocy-nginx
+++ b/Dockerfile-grocy-nginx
@@ -15,9 +15,7 @@ RUN     apk update && \
                 -out /etc/nginx/certificates/cert.pem \
                 -days 365 \
                 -nodes \
-                -subj /CN=localhost && \
-        chown nobody /var/tmp/nginx && \
-        rm -rf /var/cache/apk/*
+                -subj /CN=localhost
 
 COPY docker_nginx/nginx.conf /etc/nginx/nginx.conf
 COPY docker_nginx/common.conf /etc/nginx/common.conf


### PR DESCRIPTION
Since https://github.com/grocy/grocy-docker/pull/42, neither of the container images required to build a functioning `grocy` Docker (or OCI) image cache any data from `apk` on-filesystem.

This changeset cleans up one of the build steps that is no longer required as a result.