### PR TITLE
Improve docker build robustness

### DIFF
--- a/Dockerfile-grocy
+++ b/Dockerfile-grocy
@@ -39,7 +39,8 @@ RUN     apk update && \
         pip install lastversion==0.2.4
 
 # Extract application release package
-RUN     wget --header "Authorization: ${GITHUB_API_TOKEN}" -t 3 -T 30 -nv -O "grocy.tar.gz" $(GITHUB_API_TOKEN=${GITHUB_API_TOKEN} lastversion --source grocy/grocy) && \
+RUN     set -o pipefail && \
+        wget --header "Authorization: ${GITHUB_API_TOKEN}" -t 3 -T 30 -nv -O "grocy.tar.gz" $(GITHUB_API_TOKEN=${GITHUB_API_TOKEN} lastversion --source grocy/grocy) && \
         tar xzf grocy.tar.gz && \
         rm grocy.tar.gz && \
         mv grocy-*/* . && \

--- a/README.md
+++ b/README.md
@@ -51,6 +51,12 @@ GROCY_CULTURE: fr
 docker-compose build
 ```
 
+Note: if you experience build failures as a result of GitHub API rate limiting, you may optionally provide a GitHub API key (preferably restricted to `read:packages` scope) at build-time:
+
+```
+docker-compose --build-arg GITHUB_API_TOKEN="your-token-here"
+```
+
 ## Additional Information
 
 The docker images build are based on [Alpine](https://hub.docker.com/_/alpine/), with an extremely low footprint (less than 10 MB for nginx, and less than 70MB for grocy with php-fm. That number is eventually bumped up to 490MB after all the dependencies are downloaded, however).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 # Usage:
 # docker-compose build && docker-compose up
-version: '2'
+version: '2.4'
 
 services:
   grocy-nginx:


### PR DESCRIPTION
This changeset should early-fail the docker build process if an error is encountered during the release package download step.

Previously this step would continue even if the `wget` command failed (see #29).

This issue is indirectly linked to the removal of `lastversion` in #35 that could remove one more point of failure.

Resolves #29 