### PR TITLE
Remove nginx volumes

### DIFF
--- a/Dockerfile-grocy-nginx
+++ b/Dockerfile-grocy-nginx
@@ -18,8 +18,6 @@ RUN     apk update && \
 
 COPY docker_nginx /etc/nginx
 
-VOLUME ["/etc/nginx/conf.d", "/var/log/nginx"]
-
 EXPOSE 80 443
 
 ENTRYPOINT ["/usr/sbin/nginx", "-g", "daemon off;"]


### PR DESCRIPTION
There don't seem to be any references to the `nginx` config include directory (`/etc/nginx/conf.d`) or logging directory (`/var/log/nginx`) that are exposed as volumes in `Dockerfile-grocy-nginx`.

Until discovering a purpose or need for these, this changeset removes those volume definitions.