### PR TITLE
Reduce volume access privileges

### DIFF
--- a/Dockerfile-grocy
+++ b/Dockerfile-grocy
@@ -55,7 +55,7 @@ RUN     COMPOSER_OAUTH=${GITHUB_API_TOKEN:+"\"github.com\": \"${GITHUB_API_TOKEN
         COMPOSER_AUTH="{\"github-oauth\": { ${COMPOSER_OAUTH} }}" composer install --no-interaction --no-dev --optimize-autoloader && \
         yarn install --modules-folder /var/www/public/node_modules --production
 
-VOLUME ["/var/www"]
+VOLUME ["/var/www/public"]
 
 EXPOSE 9000
 

--- a/Dockerfile-grocy-nginx
+++ b/Dockerfile-grocy-nginx
@@ -6,7 +6,6 @@ RUN     apk update && \
             openssl \
             nginx && \
         mkdir -p /etc/nginx/certificates && \
-        mkdir -p /var/run/nginx && \
         openssl req \
                 -x509 \
                 -newkey rsa:2048 \

--- a/Dockerfile-grocy-nginx
+++ b/Dockerfile-grocy-nginx
@@ -17,6 +17,8 @@ RUN     apk update && \
 
 COPY docker_nginx /etc/nginx
 
+VOLUME ["/var/log/nginx"]
+
 EXPOSE 80 443
 
 ENTRYPOINT ["/usr/sbin/nginx", "-g", "daemon off;"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-# Usage:
-# docker-compose build && docker-compose up
 version: '2.4'
 
 services:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ services:
     ports:
       - '80:80'
       - '443:443'
+    read_only: true
     tmpfs:
       - /run/nginx
       - /var/lib/nginx/tmp:uid=100

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,10 @@ services:
     ports:
       - '80:80'
       - '443:443'
+    tmpfs:
+      - /run/nginx
+      - /var/lib/nginx/tmp:uid=100
+      - /var/log/nginx
     volumes_from:
       - grocy
     container_name: grocy-nginx

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
     expose:
       - 9000
     volumes:
-      - database:/var/www
+      - www-public:/var/www/public
     environment:
       PHP_MEMORY_LIMIT:    512M
       MAX_UPLOAD:          50M
@@ -38,4 +38,4 @@ services:
       GROCY_CULTURE: en
     container_name: grocy
 volumes:
-  database:
+  www-public:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
     tmpfs:
       - /run/nginx
       - /var/lib/nginx/tmp:uid=100
+    volumes:
       - /var/log/nginx
     volumes_from:
       - grocy:ro

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       - /var/lib/nginx/tmp:uid=100
       - /var/log/nginx
     volumes_from:
-      - grocy
+      - grocy:ro
     container_name: grocy-nginx
 
   grocy:

--- a/docker_nginx/conf.d/ssl.conf
+++ b/docker_nginx/conf.d/ssl.conf
@@ -6,8 +6,6 @@ server {
 
     ssl_certificate      /etc/nginx/certificates/cert.pem;
     ssl_certificate_key  /etc/nginx/certificates/key.pem;
-    
-    error_log /var/log/nginx/error.log;
 
     # ssl_session_cache    shared:SSL:1m;
     # ssl_session_timeout  5m;

--- a/docker_nginx/nginx.conf
+++ b/docker_nginx/nginx.conf
@@ -1,10 +1,6 @@
 user nginx;
 worker_processes auto;
 
-pid /var/run/nginx/nginx.pid;
-
-error_log /var/log/nginx/error.log warn;
-
 events {
     worker_connections 1024;
 }
@@ -35,8 +31,6 @@ http {
 	gzip_min_length 1000;
 	gzip_proxied expired no-cache no-store private auth;
 	gzip_types text/plain application/x-javascript text/xml text/css application/xml;
-	
-	access_log /var/log/nginx/access.log main;
 
     include /etc/nginx/conf.d/*.conf;
 }


### PR DESCRIPTION
- Mark container root filesystems as read-only; provide `tmpfs` mounts for truly transient data
- Only allow `nginx` container to access files under `/var/www/public` (i.e. no PHP or database content)
- Re-enable export of `nginx` log volume, since some users may wish to persist log data
- Use default `nginx` logfile paths