### PR TITLE
Reduce user privileges

### DIFF
--- a/Dockerfile-grocy
+++ b/Dockerfile-grocy
@@ -14,8 +14,6 @@ ARG GROCY_VERSION=v2.6.1
 # https://docs.docker.com/engine/reference/builder/#env
 ARG GITHUB_API_TOKEN
 
-WORKDIR /var/www
-
 # Install system dependencies
 RUN     apk update && \
         apk add --no-cache \
@@ -37,7 +35,11 @@ RUN     apk update && \
             --with-png-dir=/usr/include/ \
             --with-jpeg-dir=/usr/include/ && \
         NPROC=$(grep -c ^processor /proc/cpuinfo 2>/dev/null || 1) && \
-        docker-php-ext-install -j${NPROC} gd
+        docker-php-ext-install -j${NPROC} gd && \
+        chown -R www-data /var/www
+
+USER www-data
+WORKDIR /var/www
 
 # Extract application release package
 RUN     set -o pipefail && \
@@ -47,8 +49,7 @@ RUN     set -o pipefail && \
         mv grocy-*/* . && \
         rm -r grocy-* && \
         mkdir data/viewcache && \
-        cp config-dist.php data/config.php && \
-        chown -R www-data .
+        cp config-dist.php data/config.php
 
 # Install application dependencies
 RUN     COMPOSER_OAUTH=${GITHUB_API_TOKEN:+"\"github.com\": \"${GITHUB_API_TOKEN}\""} && \

--- a/Dockerfile-grocy-nginx
+++ b/Dockerfile-grocy-nginx
@@ -19,6 +19,6 @@ COPY docker_nginx /etc/nginx
 
 VOLUME ["/var/log/nginx"]
 
-EXPOSE 80 443
+EXPOSE 8080 8443
 
 ENTRYPOINT ["/usr/sbin/nginx", "-g", "daemon off;"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,8 +9,8 @@ services:
     depends_on:
       - grocy
     ports:
-      - '80:80'
-      - '443:443'
+      - '80:8080'
+      - '443:8443'
     read_only: true
     tmpfs:
       - /run/nginx

--- a/docker_nginx/conf.d/default.conf
+++ b/docker_nginx/conf.d/default.conf
@@ -1,5 +1,5 @@
 server {
-    listen 80 default_server;
+    listen 8080 default_server;
     server_name _;
     
     root /var/www/public; # see: volumes_from

--- a/docker_nginx/conf.d/ssl.conf
+++ b/docker_nginx/conf.d/ssl.conf
@@ -1,5 +1,5 @@
 server {
-    listen 443 ssl;
+    listen 8443 ssl;
     server_name _;
     
     root /var/www/public; # see: volumes_from


### PR DESCRIPTION
- Unpack `grocy` releases as a non-root user
- Bind to non-privileged ports within the `nginx` container

There's more that could be done here; in particular it would be nice to start the `nginx` process as non-root.  It does already drop privileges thanks to a top-level [`user` directive in `nginx.conf`](https://github.com/grocy/grocy-docker/blob/1c5819ec5354858612e189b1c93b82e5fca86e1e/docker_nginx/nginx.conf#L1), but ideally it would not even need to be run with super-user privileges in the first place.