### PR TITLE
Persist application database in a volume

### DIFF
--- a/Dockerfile-grocy
+++ b/Dockerfile-grocy
@@ -54,7 +54,7 @@ RUN     COMPOSER_OAUTH=${GITHUB_API_TOKEN:+"\"github.com\": \"${GITHUB_API_TOKEN
         COMPOSER_AUTH="{\"github-oauth\": { ${COMPOSER_OAUTH} }}" composer install --no-interaction --no-dev --optimize-autoloader && \
         yarn install --modules-folder /var/www/public/node_modules --production
 
-VOLUME ["/var/www/public"]
+VOLUME ["/var/www/data", "/var/www/public"]
 
 EXPOSE 9000
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,7 @@ services:
     expose:
       - 9000
     volumes:
+      - database:/var/www/data
       - www-public:/var/www/public
     environment:
       PHP_MEMORY_LIMIT:    512M
@@ -38,4 +39,5 @@ services:
       GROCY_CULTURE: en
     container_name: grocy
 volumes:
+  database:
   www-public:


### PR DESCRIPTION
Restores the notion of a `database` named volume, but ensures that it only contains the contents of the PHP application's SQLite database (and application config).