### PR TITLE
Enable read-only image filesystem for grocy container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,9 @@ services:
       dockerfile: Dockerfile-grocy
     expose:
       - 9000
+    read_only: true
+    tmpfs:
+      - /tmp
     volumes:
       - database:/var/www/data
       - www-public:/var/www/public


### PR DESCRIPTION
Tested locally; enabling a read-only image filesystem requires mounting a `tmpfs` filesystem at `/tmp` in order for equipment document uploads to succeed.