### PR TITLE
Remove nginx permission workaround

### DIFF
--- a/Dockerfile-grocy-nginx
+++ b/Dockerfile-grocy-nginx
@@ -15,6 +15,8 @@ RUN     apk update && \
                 -nodes \
                 -subj /CN=localhost
 
+RUN     chmod go+rx /var/lib/nginx/tmp
+
 COPY docker_nginx /etc/nginx
 
 VOLUME ["/var/log/nginx"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     read_only: true
     tmpfs:
       - /run/nginx
-      - /var/lib/nginx/tmp:uid=100  # uid=100 ensures that nginx has execute permission on this dir
+      - /var/lib/nginx/tmp
     volumes:
       - /var/log/nginx
       - www-public:/var/www/public:ro


### PR DESCRIPTION
This is a small cleanup for an ugly workaround that specified the `uid` mount option for a temporary directory in the `docker-compose.yml` file.

Although it's still not ideal, it's preferable (and more compatible with https://github.com/grocy/grocy-docker/pull/46) to provide this access via a Dockerfile `RUN ... chmod` instruction.