### PR TITLE
nginx: bind to non-privileged container ports

### DIFF
--- a/Dockerfile-grocy-nginx
+++ b/Dockerfile-grocy-nginx
@@ -21,6 +21,6 @@ COPY docker_nginx /etc/nginx
 
 VOLUME ["/var/log/nginx"]
 
-EXPOSE 80 443
+EXPOSE 8080 8443
 
 ENTRYPOINT ["/usr/sbin/nginx", "-g", "daemon off;"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
       context: .
       dockerfile: Dockerfile-grocy
     expose:
-      - 9000
+      - '9000'
     read_only: true
     tmpfs:
       - /tmp

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,8 +9,8 @@ services:
     depends_on:
       - grocy
     ports:
-      - '80:80'
-      - '443:443'
+      - '80:8080'
+      - '443:8443'
     read_only: true
     tmpfs:
       - /run/nginx

--- a/docker_nginx/conf.d/default.conf
+++ b/docker_nginx/conf.d/default.conf
@@ -1,5 +1,5 @@
 server {
-    listen 80 default_server;
+    listen 8080 default_server;
     server_name _;
     
     root /var/www/public; # see: volumes_from

--- a/docker_nginx/conf.d/ssl.conf
+++ b/docker_nginx/conf.d/ssl.conf
@@ -1,5 +1,5 @@
 server {
-    listen 443 ssl;
+    listen 8443 ssl;
     server_name _;
     
     root /var/www/public; # see: volumes_from


### PR DESCRIPTION
This changeset introduces further work towards lowering the privileges that `nginx` requires at runtime.  `docker-compose` will still publish on the same host network ports, so no documentation or end-user behaviour change should be required.