### PR TITLE
nginx: run as unprivileged user account

### DIFF
--- a/Dockerfile-grocy-nginx
+++ b/Dockerfile-grocy-nginx
@@ -15,7 +15,8 @@ RUN     apk update && \
                 -nodes \
                 -subj /CN=localhost && \
         chmod a=r /etc/nginx/certificates/key.pem && \
-        chmod a=r /etc/nginx/certificates/cert.pem
+        chmod a=r /etc/nginx/certificates/cert.pem && \
+        chown -R nginx /var/log/nginx
 
 COPY docker_nginx /etc/nginx
 

--- a/Dockerfile-grocy-nginx
+++ b/Dockerfile-grocy-nginx
@@ -13,7 +13,9 @@ RUN     apk update && \
                 -out /etc/nginx/certificates/cert.pem \
                 -days 365 \
                 -nodes \
-                -subj /CN=localhost
+                -subj /CN=localhost && \
+        chmod a=r /etc/nginx/certificates/key.pem && \
+        chmod a=r /etc/nginx/certificates/cert.pem
 
 RUN     chmod go+rx /var/lib/nginx/tmp
 

--- a/Dockerfile-grocy-nginx
+++ b/Dockerfile-grocy-nginx
@@ -5,17 +5,17 @@ RUN     apk update && \
         apk add --no-cache \
             openssl \
             nginx && \
-        mkdir -p /etc/nginx/certificates && \
         openssl req \
                 -x509 \
                 -newkey rsa:2048 \
-                -keyout /etc/nginx/certificates/key.pem \
-                -out /etc/nginx/certificates/cert.pem \
+                -keyout /etc/ssl/private/grocy-nginx.key \
+                -out /etc/ssl/private/grocy-nginx.crt \
                 -days 365 \
                 -nodes \
                 -subj /CN=localhost && \
-        chmod a=r /etc/nginx/certificates/key.pem && \
-        chmod a=r /etc/nginx/certificates/cert.pem && \
+        chown -R root:www-data /etc/ssl/private && \
+        chmod -R o-rwx /etc/ssl/private && \
+        chmod -R g+rx /etc/ssl/private && \
         chown -R nginx /var/log/nginx
 
 COPY docker_nginx /etc/nginx

--- a/Dockerfile-grocy-nginx
+++ b/Dockerfile-grocy-nginx
@@ -24,4 +24,6 @@ VOLUME ["/var/log/nginx"]
 
 EXPOSE 8080 8443
 
+USER nginx
+
 ENTRYPOINT ["/usr/sbin/nginx", "-g", "daemon off;"]

--- a/Dockerfile-grocy-nginx
+++ b/Dockerfile-grocy-nginx
@@ -17,8 +17,6 @@ RUN     apk update && \
         chmod a=r /etc/nginx/certificates/key.pem && \
         chmod a=r /etc/nginx/certificates/cert.pem
 
-RUN     chmod go+rx /var/lib/nginx/tmp
-
 COPY docker_nginx /etc/nginx
 
 VOLUME ["/var/log/nginx"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,6 @@ services:
       - '443:8443'
     read_only: true
     tmpfs:
-      - /run/nginx
       - /tmp
     volumes:
       - /var/log/nginx

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,6 @@ services:
     read_only: true
     tmpfs:
       - /run/nginx
-      - /var/lib/nginx/tmp
       - /tmp
     volumes:
       - /var/log/nginx

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
     tmpfs:
       - /run/nginx
       - /var/lib/nginx/tmp
+      - /tmp
     volumes:
       - /var/log/nginx
       - www-public:/var/www/public:ro

--- a/docker_nginx/conf.d/ssl.conf
+++ b/docker_nginx/conf.d/ssl.conf
@@ -4,8 +4,8 @@ server {
     
     root /var/www/public; # see: volumes_from
 
-    ssl_certificate      /etc/nginx/certificates/cert.pem;
-    ssl_certificate_key  /etc/nginx/certificates/key.pem;
+    ssl_certificate      /etc/ssl/private/grocy-nginx.crt;
+    ssl_certificate_key  /etc/ssl/private/grocy-nginx.key;
 
     # ssl_session_cache    shared:SSL:1m;
     # ssl_session_timeout  5m;

--- a/docker_nginx/nginx.conf
+++ b/docker_nginx/nginx.conf
@@ -1,11 +1,19 @@
 user nginx;
 worker_processes auto;
 
+pid /tmp/nginx.pid;
+
 events {
     worker_connections 1024;
 }
 
 http {
+    client_body_temp_path /tmp/client_temp;
+    proxy_temp_path       /tmp/proxy_temp_path;
+    fastcgi_temp_path     /tmp/fastcgi_temp;
+    uwsgi_temp_path       /tmp/uwsgi_temp;
+    scgi_temp_path        /tmp/scgi_temp;
+
     include mime.types;
     default_type application/octet-stream;
 

--- a/docker_nginx/nginx.conf
+++ b/docker_nginx/nginx.conf
@@ -1,4 +1,3 @@
-user nginx;
 worker_processes auto;
 
 pid /tmp/nginx.pid;


### PR DESCRIPTION
- Includes configuration changes from Docker's [official nginx image documentation](https://hub.docker.com/_/nginx) regarding running `nginx` as non-root
- Ensures `nginx` user account owns access and error logs (stored in a Docker volume with persistent UIDs)
- Migrates TLS cert and key to a new directory and enforces slightly stronger access control
- Reduces the privileges that the `nginx` process runs under