### PR TITLE
nginx: configuration cleanup

### DIFF
--- a/docker_nginx/common.conf
+++ b/docker_nginx/common.conf
@@ -5,7 +5,7 @@ location / {
 }
 
 location ~* .(jpg|jpeg|png|gif|ico|css|js)$ {
-	expires 365d;
+    expires 365d;
 }
 
 location ~ \.php$ {

--- a/docker_nginx/conf.d/ssl.conf
+++ b/docker_nginx/conf.d/ssl.conf
@@ -6,12 +6,6 @@ server {
 
     ssl_certificate      /etc/ssl/private/grocy-nginx.crt;
     ssl_certificate_key  /etc/ssl/private/grocy-nginx.key;
-
-    # ssl_session_cache    shared:SSL:1m;
-    # ssl_session_timeout  5m;
-
-    # ssl_ciphers  HIGH:!aNULL:!MD5;
-    # ssl_prefer_server_ciphers  on;
     
     include /etc/nginx/common.conf;
 }

--- a/docker_nginx/conf.d/ssl.conf
+++ b/docker_nginx/conf.d/ssl.conf
@@ -14,5 +14,4 @@ server {
     # ssl_prefer_server_ciphers  on;
     
     include /etc/nginx/common.conf;
-
 }

--- a/docker_nginx/nginx.conf
+++ b/docker_nginx/nginx.conf
@@ -17,7 +17,7 @@ http {
     default_type application/octet-stream;
 
     gzip on;
-    gzip_types application/javascript application/json application/octet-stream font/woff font/woff2 text/css;
+    gzip_types application/javascript application/json application/octet-stream application/pdf font/woff font/woff2 text/css;
 
     include /etc/nginx/conf.d/*.conf;
 }

--- a/docker_nginx/nginx.conf
+++ b/docker_nginx/nginx.conf
@@ -17,7 +17,7 @@ http {
     default_type application/octet-stream;
 
     gzip on;
-    gzip_types application/javascript application/json application/octet-stream application/pdf font/woff font/woff2 text/css;
+    gzip_types application/javascript application/json application/octet-stream application/pdf font/woff font/woff2 image/gif image/jpeg image/png image/webp image/x-icon text/css;
 
     include /etc/nginx/conf.d/*.conf;
 }

--- a/docker_nginx/nginx.conf
+++ b/docker_nginx/nginx.conf
@@ -16,27 +16,7 @@ http {
     include mime.types;
     default_type application/octet-stream;
 
-    log_format main '$remote_addr - $remote_user [$time_local] "$request" '
-                    '$status $body_bytes_sent "$http_referer" '
-                    '"$http_user_agent" "$http_x_forwarded_for"';
-
-    sendfile on;
-    #tcp_nopush on;
-
-    client_body_timeout 12;
-	client_header_timeout 12;
-	keepalive_timeout 15;
-	send_timeout 10;
-	
-	client_body_buffer_size 10K;
-	client_header_buffer_size 1k;
-	client_max_body_size 50M;
-	large_client_header_buffers 2 1k;
-
     gzip on;
-	gzip_comp_level 2;
-	gzip_min_length 1000;
-	gzip_proxied expired no-cache no-store private auth;
 	gzip_types text/plain application/x-javascript text/xml text/css application/xml;
 
     include /etc/nginx/conf.d/*.conf;

--- a/docker_nginx/nginx.conf
+++ b/docker_nginx/nginx.conf
@@ -17,7 +17,7 @@ http {
     default_type application/octet-stream;
 
     gzip on;
-	gzip_types text/plain application/x-javascript text/xml text/css application/xml;
+    gzip_types application/javascript application/json application/octet-stream font/woff font/woff2 text/css;
 
     include /etc/nginx/conf.d/*.conf;
 }


### PR DESCRIPTION
- Remove cruft
- Rely on sensible nginx built-in defaults
- Enable compression for content-types used in `grocy`