### PR TITLE
Use apk package-managed installation of php7-gd

### DIFF
--- a/Dockerfile-grocy
+++ b/Dockerfile-grocy
@@ -1,4 +1,4 @@
-FROM php:7.2-fpm-alpine
+FROM alpine:latest
 LABEL maintainer "James Addison <jay@jp-hosting.net>"
 
 ARG GROCY_VERSION=v2.6.1
@@ -14,6 +14,15 @@ ARG GROCY_VERSION=v2.6.1
 # https://docs.docker.com/engine/reference/builder/#env
 ARG GITHUB_API_TOKEN
 
+# ensure www-data user exists
+RUN set -eux; \
+	addgroup -g 82 -S www-data; \
+	adduser -u 82 -D -S -G www-data www-data
+# 82 is the standard uid/gid for "www-data" in Alpine
+# https://git.alpinelinux.org/aports/tree/main/apache2/apache2.pre-install?h=3.9-stable
+# https://git.alpinelinux.org/aports/tree/main/lighttpd/lighttpd.pre-install?h=3.9-stable
+# https://git.alpinelinux.org/aports/tree/main/nginx/nginx.pre-install?h=3.9-stable
+
 # Install system dependencies
 RUN     apk update && \
         apk add --no-cache \
@@ -21,20 +30,18 @@ RUN     apk update && \
             yarn \
             git \
             wget \
-            freetype \
-            libpng \
-            libjpeg-turbo \
-            freetype-dev \
-            libpng-dev \
-            libjpeg-turbo-dev && \
-        docker-php-ext-configure gd \
-            --with-gd \
-            --with-freetype-dir=/usr/include/ \
-            --with-png-dir=/usr/include/ \
-            --with-jpeg-dir=/usr/include/ && \
-        NPROC=$(grep -c ^processor /proc/cpuinfo 2>/dev/null || 1) && \
-        docker-php-ext-install -j${NPROC} gd && \
+            php7-fpm \
+            php7-fileinfo \
+            php7-gd \
+            php7-pdo_sqlite \
+            php7-simplexml \
+            php7-tokenizer && \
+        mkdir -p /var/log/php7 && \
+        chown -R www-data /var/log/php7 && \
+        mkdir -p /var/www && \
         chown -R www-data /var/www
+
+COPY docker_grocy/www.conf /etc/php7/php-fpm.d/zz-docker.conf
 
 USER www-data
 WORKDIR /var/www
@@ -58,4 +65,4 @@ VOLUME ["/var/www/data", "/var/www/public"]
 
 EXPOSE 9000
 
-ENTRYPOINT ["php-fpm", "--nodaemonize"]
+ENTRYPOINT ["/usr/sbin/php-fpm7", "--nodaemonize"]

--- a/Dockerfile-grocy
+++ b/Dockerfile-grocy
@@ -65,4 +65,4 @@ VOLUME ["/var/www/data", "/var/www/public"]
 
 EXPOSE 9000
 
-ENTRYPOINT ["/usr/sbin/php-fpm7", "--nodaemonize"]
+ENTRYPOINT ["/usr/sbin/php-fpm7"]

--- a/README.md
+++ b/README.md
@@ -57,9 +57,5 @@ Note: if you experience build failures as a result of GitHub API rate limiting, 
 docker-compose build --build-arg GITHUB_API_TOKEN="your-token-here"
 ```
 
-## Additional Information
-
-The docker images build are based on [Alpine](https://hub.docker.com/_/alpine/), with an extremely low footprint (less than 10 MB for nginx, and less than 70MB for grocy with php-fm. That number is eventually bumped up to 490MB after all the dependencies are downloaded, however).
-
 ## License
 The MIT License (MIT)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,7 @@ services:
     tmpfs:
       - /tmp
     volumes:
+      - /var/log/php7
       - database:/var/www/data
       - www-public:/var/www/public
     env_file:

--- a/docker_grocy/www.conf
+++ b/docker_grocy/www.conf
@@ -1,0 +1,5 @@
+[global]
+daemonize = no
+
+[www]
+listen = 9000

--- a/docker_grocy/www.conf
+++ b/docker_grocy/www.conf
@@ -3,4 +3,4 @@ daemonize = no
 
 [www]
 clear_env = no
-listen = 9000
+listen = 127.0.0.1:9000

--- a/docker_grocy/www.conf
+++ b/docker_grocy/www.conf
@@ -2,4 +2,5 @@
 daemonize = no
 
 [www]
+clear_env = no
 listen = 9000

--- a/docker_grocy/www.conf
+++ b/docker_grocy/www.conf
@@ -3,4 +3,4 @@ daemonize = no
 
 [www]
 clear_env = no
-listen = 127.0.0.1:9000
+listen = 9000


### PR DESCRIPTION
Although it requires a couple of other small changes as a side-effect, we can remove the requirement for code compilation at `grocy` container build-time by using a version of [`php7-gd` from `apk`](https://pkgs.alpinelinux.org/package/v3.11/community/x86/php7-gd).

Resolves #50 
Resolves #69 