### PR TITLE
added env var info to readme and grocy.env

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,11 @@ docker pull grocy/grocy-docker:grocy
 
 Or just `docker-compose pull`.
 
-### Environmental variables:
+### Environment variables:
 
-As of grocy v.1.24.1, ENV variables are accessible via the `docker-compose.yml` file as long as they are prefixed by `GROCY_`. For example, to change the language from English to French, you can modify
+As of grocy v1.24.1, grocy will read configuration settings from environment variables as long as they are prefixed by `GROCY_`. Some key items are included in  `grocy.env`. The shipped version of this file sets `GROCY_MODE=demo`, which will load some sample entries into the database, and doesn't require authentication. Set `GROCY_MODE=production` to put the application in production mode and require login. 
+
+For example, to change the language from English to French, you can modify
 
 ```
 GROCY_CULTURE: en

--- a/grocy.env
+++ b/grocy.env
@@ -1,10 +1,18 @@
-# Grocy Environment Variables for config settings
-# For other settings, see config-dist in the main grocy repo: 
+# Grocy Environment Variables
+#
+# These environment variables affect PHP and the grocy application
+#
+# For a full list of grocy settings, see config-dist.php in the main grocy repo:
+#
 #       https://github.com/grocy/grocy/blob/master/config-dist.php
-# The setting name must be prefixed with GROCY_ when used here as an 
-# environment variable. For instance, for this line in config-dist.php:
-# Setting('CURRENCY', 'USD');
-# Set an environment variable, eg GROCY_CURRENCY=EUR to use Euros. 
+#
+# Grocy application settings must be prefixed with 'GROCY_'.
+#
+# For example, if we'd like to configure grocy to use Euros (EUR):
+#
+#       Setting('CURRENCY', 'USD');
+#
+# Then we would set GROCY_CURRENCY='EUR'. 
 
 # GROCY_CULTURE sets the language. See main repo's localiation directory
 # for a list of valid values: https://github.com/grocy/grocy/tree/master/localization

--- a/grocy.env
+++ b/grocy.env
@@ -14,8 +14,8 @@
 #
 # Then we would set GROCY_CURRENCY='EUR'. 
 
-# GROCY_CULTURE sets the language. See main repo's localiation directory
-# for a list of valid values: https://github.com/grocy/grocy/tree/master/localization
+# GROCY_CULTURE configures localization of the grocy application
+# Supported locales: https://github.com/grocy/grocy/tree/master/localization
 GROCY_CULTURE=en
 
 # Change to GROCY_MODE=production for actual use

--- a/grocy.env
+++ b/grocy.env
@@ -18,7 +18,7 @@
 # Supported locales: https://github.com/grocy/grocy/tree/master/localization
 GROCY_CULTURE=en
 
-# Change to GROCY_MODE=production for actual use
+# This should be set to GROCY_MODE=production for production deployments
 GROCY_MODE=demo
 
 # As of v2.6.1, there is a bug that doesn't redirect users to login if GROCY_ENTRY_PAGE 

--- a/grocy.env
+++ b/grocy.env
@@ -1,5 +1,24 @@
+# Grocy Environment Variables for config settings
+# For other settings, see config-dist in the main grocy repo: 
+#       https://github.com/grocy/grocy/blob/master/config-dist.php
+# The setting name must be prefixed with GROCY_ when used here as an 
+# environment variable. For instance, for this line in config-dist.php:
+# Setting('CURRENCY', 'USD');
+# Set an environment variable, eg GROCY_CURRENCY=EUR to use Euros. 
+
+# GROCY_CULTURE sets the language. See main repo's localiation directory
+# for a list of valid values: https://github.com/grocy/grocy/tree/master/localization
 GROCY_CULTURE=en
-GROCY_MODE
+
+# Change to GROCY_MODE=production for actual use
+GROCY_MODE=demo
+
+# As of v2.6.1, there is a bug that doesn't redirect users to login if GROCY_ENTRY_PAGE 
+# is set to the default value of 'stock'. Setting this to shoppinglist ensures that
+# users are sent to login when GROCY_MODE=production. 
+GROCY_ENTRY_PAGE=shoppinglist
+
+# PHP Environment variables
 MAX_UPLOAD=50M
 PHP_MAX_FILE_UPLOAD=200
 PHP_MAX_POST=100M

--- a/grocy.env
+++ b/grocy.env
@@ -21,11 +21,6 @@ GROCY_CULTURE=en
 # This should be set to GROCY_MODE=production for production deployments
 GROCY_MODE=demo
 
-# As of v2.6.1, there is a bug that doesn't redirect users to login if GROCY_ENTRY_PAGE 
-# is set to the default value of 'stock'. Setting this to shoppinglist ensures that
-# users are sent to login when GROCY_MODE=production. 
-GROCY_ENTRY_PAGE=shoppinglist
-
 # PHP Environment variables
 MAX_UPLOAD=50M
 PHP_MAX_FILE_UPLOAD=200


### PR DESCRIPTION
Made some suggested edits to `README.md` about environment variables.

Also added explanatory comments to `grocy.env`, and two actual changes: explicitly setting `GROCY_MODE=demo` seems like a good idea for people who just want to pull the repo, start up the containers, and have something that works. If you prefer it to be `production`, I think it should be set explicitly rather than implicitly by setting it null. 

Also added  `GROCY_ENTRY_PAGE=shoppinglist` as a workaround to [issue #689](https://github.com/grocy/grocy/issues/689) I reported on the upstream repo. 
