### PR TITLE
Prune non-essential vendor content from container images

### DIFF
--- a/Dockerfile-grocy
+++ b/Dockerfile-grocy
@@ -63,6 +63,11 @@ RUN     find /var/www/public/node_modules \
             -exec rm {} \; && \
         find /var/www/public/node_modules \
             -type d \
+            -name 'src' \
+            -and -not -path '*/gettext-translator/src' \
+            -exec rm {} \; && \
+        find /var/www/public/node_modules \
+            -type d \
             -name 'docs' \
             -exec rm {} \;
 

--- a/Dockerfile-grocy
+++ b/Dockerfile-grocy
@@ -62,7 +62,6 @@ RUN     find /var/www/public/node_modules \
             -and -not -name '*.ttf' \
             -and -not -name '*.woff' \
             -and -not -name '*.woff2' \
-            -and -not -name 'search_plus_index.json' \
             -exec rm {} \; && \
         find /var/www/public/node_modules \
             -depth \

--- a/Dockerfile-grocy
+++ b/Dockerfile-grocy
@@ -59,6 +59,9 @@ RUN     find /var/www/public/node_modules \
             -type f \
             -not -name '*.js' \
             -and -not -name '*.css' \
+            -and -not -name '*.ttf' \
+            -and -not -name '*.woff' \
+            -and -not -name '*.woff2' \
             -and -not -name 'search_plus_index.json' \
             -exec rm {} \; && \
         find /var/www/public/node_modules \

--- a/Dockerfile-grocy
+++ b/Dockerfile-grocy
@@ -54,6 +54,18 @@ RUN     COMPOSER_OAUTH=${GITHUB_API_TOKEN:+"\"github.com\": \"${GITHUB_API_TOKEN
         COMPOSER_AUTH="{\"github-oauth\": { ${COMPOSER_OAUTH} }}" composer install --no-interaction --no-dev --optimize-autoloader && \
         yarn install --modules-folder /var/www/public/node_modules --production
 
+# Prune vendored content
+RUN     find /var/www/public/node_modules \
+            -type f \
+            -not -name '*.js' \
+            -and -not -name '*.css' \
+            -and -not -name 'search_plus_index.json' \
+            -exec rm {} \; && \
+        find /var/www/public/node_modules \
+            -type d \
+            -name 'docs' \
+            -exec rm {} \;
+
 VOLUME ["/var/www/data", "/var/www/public"]
 
 EXPOSE 9000

--- a/Dockerfile-grocy
+++ b/Dockerfile-grocy
@@ -62,14 +62,16 @@ RUN     find /var/www/public/node_modules \
             -and -not -name 'search_plus_index.json' \
             -exec rm {} \; && \
         find /var/www/public/node_modules \
+            -depth \
             -type d \
             -name 'src' \
             -and -not -path '*/gettext-translator/src' \
-            -exec rm {} \; && \
+            -exec rm -rf {} \; && \
         find /var/www/public/node_modules \
+            -depth \
             -type d \
             -name 'docs' \
-            -exec rm {} \;
+            -exec rm -rf {} \;
 
 VOLUME ["/var/www/data", "/var/www/public"]
 


### PR DESCRIPTION
This changeset reduces the size of the grocy application image by pruning vendor dependency files that appear unused.

It is difficult to _guarantee_ that files are unused -- vendor code (both PHP and Javascript code) may itself contain file access paths and internal file dependencies.

This changeset makes a best-effort to clean up files that appear unused, while keeping files that are known to be accessible.

The following command(s) were used while investigating files to keep:
```sh
# context: grocy application container

# 1. find references to yarn vendored content
/var/www $ grep -rw node_modules 'public/viewjs' 'views'
...
# 2. repeat previous step, now ignoring javascript and css content
/var/www $ grep -rw node_modules 'public/viewjs' 'views' | grep -vw 'js' | grep -vw 'css'

# 3. look for references to vendor content in directories named 'src'
/var/www $ grep -rw node_modules 'views' 'public/viewjs' | grep 'src/'
```

Relates to discussion in https://github.com/grocy/grocy/issues/640#issuecomment-602259408 (this is not a complete fix, but may be worthwhile given the available savings)

Todo:

- [ ] Add size reduction statistics (appears to be 15%+ / 40MB+ size reduction for grocy application image)