### PR TITLE
Mount www-public read-only in 'grocy' PHP container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,7 @@ services:
       - /tmp
     volumes:
       - database:/var/www/data
-      - www-public:/var/www/public
+      - www-public:/var/www/public:ro
     env_file:
       - grocy.env
     container_name: grocy


### PR DESCRIPTION
The `www-public` volume does not need to be mounted writable in the PHP container (aka [`grocy` service](https://github.com/grocy/grocy-docker/blob/57be601e89256553deb509037c6a0fb4b446b06a/docker-compose.yml#L22) according to `docker-compose.yml`).

Really, the only reason it needs to be a volume at all is that it holds static content served by the (separate) [`nginx` service container](https://github.com/grocy/grocy-docker/blob/57be601e89256553deb509037c6a0fb4b446b06a/docker-compose.yml#L4).

This changeset improves the current situation by ensuring that the volume is mounted `ro` (read-only)

Alternative future options for improvement include:

- Migrating or binding the static content into the `nginx` image directly, without using a host-persistent volume (this option is the most efficient)
- Allowing the PHP container to serve the static content (this option seems wasteful since `nginx` should be efficient for static delivery, yet would leave it performing little work)
- Combining both existing containers into a single image (simple and efficient, but reduces security boundaries)

cc @tet3