### PR TITLE
After yarn installs dependencies, clear the yarn cache

### DIFF
--- a/Dockerfile-grocy
+++ b/Dockerfile-grocy
@@ -52,7 +52,8 @@ RUN     set -o pipefail && \
 # Install application dependencies
 RUN     COMPOSER_OAUTH=${GITHUB_API_TOKEN:+"\"github.com\": \"${GITHUB_API_TOKEN}\""} && \
         COMPOSER_AUTH="{\"github-oauth\": { ${COMPOSER_OAUTH} }}" composer install --no-interaction --no-dev --optimize-autoloader && \
-        yarn install --modules-folder /var/www/public/node_modules --production
+        yarn install --modules-folder /var/www/public/node_modules --production && \
+        yarn cache clean
 
 VOLUME ["/var/www/data", "/var/www/public"]
 


### PR DESCRIPTION
This should be a straightforward and safe improvement for Docker image builds.

`yarn` stores a local cache of downloaded modules in the current user's home directory during installation.  These cache files are only used for the purposes of speeding up future installation steps, and are not accessed by the containerized application.

Removing the cache reduces the `grocy` PHP container size by over 100MB:

```
grocy-docker$ git checkout master
grocy-docker$ git rev-parse --short HEAD
12a7064
grocy-docker$ GROCY_VERSION=v2.6.1 docker-compose build > /dev/null
Building grocy
Building grocy-nginx
grocy-docker$ docker images --filter reference=grocy/grocy-docker
REPOSITORY           TAG                 IMAGE ID            CREATED             SIZE
grocy/grocy-docker   nginx               c324f0f1e5e1        5 seconds ago       9.24MB
grocy/grocy-docker   grocy               9aad416224d1        9 seconds ago       352MB

grocy-docker$ git checkout clear-yarn-build-cache 
grocy-docker$ git rev-parse --short HEAD 
34a4371
grocy-docker$ GROCY_VERSION=v2.6.1 docker-compose build > /dev/null
Building grocy
Building grocy-nginx
grocy-docker$ docker images --filter reference=grocy/grocy-docker
REPOSITORY           TAG                 IMAGE ID            CREATED             SIZE
grocy/grocy-docker   grocy               7b8420725093        35 seconds ago      239MB
grocy/grocy-docker   nginx               1b4971b15261        5 minutes ago       9.24MB
```