### PR TITLE
Bind to loopback interfaces by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ build: pod grocy nginx
 
 pod:
 	podman pod rm -f grocy-pod || true
-	podman pod create --name grocy-pod --publish 8080
+	podman pod create --name grocy-pod --publish 127.0.0.1:8080:8080
 
 grocy:
 	podman image exists $@:${IMAGE_TAG} || buildah bud --build-arg GITHUB_API_TOKEN=${GITHUB_API_TOKEN} --build-arg GROCY_VERSION=${GROCY_VERSION} -f Dockerfile-grocy -t $@:${IMAGE_TAG} .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,8 +10,8 @@ services:
     depends_on:
       - grocy
     ports:
-      - '80:8080'
-      - '443:8443'
+      - '127.0.0.1:80:8080'
+      - '127.0.0.1:443:8443'
     read_only: true
     tmpfs:
       - /tmp


### PR DESCRIPTION
This was an oversight on my behalf; both the OCI and docker-compose utilities should bind to the loopback network interface by default.