### PR TITLE
Remove use of shared volume between grocy/grocy & grocy/nginx containers

### DIFF
--- a/Dockerfile-grocy
+++ b/Dockerfile-grocy
@@ -23,12 +23,6 @@ RUN set -eux; \
 # https://git.alpinelinux.org/aports/tree/main/lighttpd/lighttpd.pre-install?h=3.9-stable
 # https://git.alpinelinux.org/aports/tree/main/nginx/nginx.pre-install?h=3.9-stable
 
-# Configure directory permissions
-RUN     mkdir /var/log/php7 && \
-        chown www-data /var/log/php7 && \
-        mkdir /var/www && \
-        chown www-data /var/www
-
 # Install build-time dependencies
 RUN     apk add --no-cache \
             composer \
@@ -47,6 +41,11 @@ RUN     apk add --no-cache \
             php7-pdo_sqlite \
             php7-simplexml \
             php7-tokenizer
+
+# Configure directory permissions
+RUN     chown www-data /var/log/php7 && \
+        mkdir /var/www && \
+        chown www-data /var/www
 
 COPY docker_grocy/www.conf /etc/php7/php-fpm.d/zz-docker.conf
 

--- a/Dockerfile-grocy
+++ b/Dockerfile-grocy
@@ -76,7 +76,7 @@ RUN     apk del \
             gnupg \
             wget
 
-VOLUME ["/var/www/data", "/var/www/public"]
+VOLUME ["/var/www/data"]
 
 EXPOSE 9000
 

--- a/Dockerfile-grocy
+++ b/Dockerfile-grocy
@@ -26,7 +26,6 @@ RUN set -eux; \
 # Install build-time dependencies
 RUN     apk add --no-cache \
             composer \
-            yarn \
             git \
             gnupg \
             wget
@@ -67,15 +66,12 @@ RUN     set -o pipefail && \
 # Install application dependencies
 RUN     COMPOSER_OAUTH=${GITHUB_API_TOKEN:+"\"github.com\": \"${GITHUB_API_TOKEN}\""} && \
         COMPOSER_AUTH="{\"github-oauth\": { ${COMPOSER_OAUTH} }}" composer install --no-interaction --no-dev --optimize-autoloader && \
-        composer clear-cache && \
-        yarn install --modules-folder /var/www/public/node_modules --production && \
-        yarn cache clean
+        composer clear-cache
 
 # Remove build-time dependencies (privileged)
 USER root
 RUN     apk del \
             composer \
-            yarn \
             git \
             gnupg \
             wget

--- a/Dockerfile-grocy
+++ b/Dockerfile-grocy
@@ -14,8 +14,6 @@ ARG GROCY_VERSION
 # https://docs.docker.com/engine/reference/builder/#env
 ARG GITHUB_API_TOKEN
 
-ENV GROCY_RELEASE_KEY_URI="https://berrnd.de/data/Bernd_Bestel.asc"
-
 # ensure www-data user exists
 RUN set -eux; \
 	addgroup -g 82 -S www-data; \
@@ -57,6 +55,7 @@ USER www-data
 WORKDIR /var/www
 
 # Extract application release package
+ENV GROCY_RELEASE_KEY_URI="https://berrnd.de/data/Bernd_Bestel.asc"
 RUN     set -o pipefail && \
         export GNUPGHOME=$(mktemp -d) && \
         wget ${GROCY_RELEASE_KEY_URI} -O - | gpg --batch --import && \

--- a/Dockerfile-grocy-nginx
+++ b/Dockerfile-grocy-nginx
@@ -3,10 +3,16 @@ LABEL maintainer "Talmai Oliveira <to@talm.ai>, James Addison <jay@jp-hosting.ne
 
 ARG GROCY_VERSION
 
+# Install build-time dependencies
 RUN     apk add --no-cache \
-            openssl \
-            nginx && \
-        openssl req \
+            openssl
+
+# Install system dependencies
+RUN     apk add --no-cache \
+            nginx
+
+# Generate TLS certificates
+RUN     openssl req \
                 -x509 \
                 -newkey rsa:2048 \
                 -keyout /etc/ssl/private/grocy-nginx.key \
@@ -15,8 +21,10 @@ RUN     apk add --no-cache \
                 -nodes \
                 -subj /CN=localhost && \
         chown nginx /etc/ssl/private/grocy-nginx.key && \
-        chown nginx /etc/ssl/private/grocy-nginx.crt && \
-        chown -R nginx /var/log/nginx
+        chown nginx /etc/ssl/private/grocy-nginx.crt
+
+# Configure directory permissions
+RUN     chown -R nginx /var/log/nginx
 
 COPY docker_nginx/nginx.conf /etc/nginx/nginx.conf
 COPY docker_nginx/common.conf /etc/nginx/common.conf

--- a/Dockerfile-grocy-nginx
+++ b/Dockerfile-grocy-nginx
@@ -28,7 +28,8 @@ RUN     openssl req \
 
 # Configure directory permissions
 RUN     chown -R nginx /var/log/nginx && \
-        rm -rf /var/www/localhost
+        rm -rf /var/www/localhost && \
+        chown nginx /var/www
 
 COPY docker_nginx/nginx.conf /etc/nginx/nginx.conf
 COPY docker_nginx/common.conf /etc/nginx/common.conf

--- a/Dockerfile-grocy-nginx
+++ b/Dockerfile-grocy-nginx
@@ -5,7 +5,10 @@ ARG GROCY_VERSION
 
 # Install build-time dependencies
 RUN     apk add --no-cache \
-            openssl
+            openssl \
+            git \
+            gnupg \
+            wget
 
 # Install system dependencies
 RUN     apk add --no-cache \
@@ -24,7 +27,8 @@ RUN     openssl req \
         chown nginx /etc/ssl/private/grocy-nginx.crt
 
 # Configure directory permissions
-RUN     chown -R nginx /var/log/nginx
+RUN     chown -R nginx /var/log/nginx && \
+        rm -rf /var/www/localhost
 
 COPY docker_nginx/nginx.conf /etc/nginx/nginx.conf
 COPY docker_nginx/common.conf /etc/nginx/common.conf
@@ -33,7 +37,10 @@ COPY docker_nginx/conf.d/ssl.conf /etc/nginx/conf.d/ssl.conf
 
 # Remove build-time dependencies
 RUN     apk del \
-            openssl
+            openssl \
+            git \
+            gnupg \
+            wget
 
 VOLUME ["/var/log/nginx"]
 

--- a/Dockerfile-grocy-nginx
+++ b/Dockerfile-grocy-nginx
@@ -8,7 +8,8 @@ RUN     apk add --no-cache \
             openssl \
             git \
             gnupg \
-            wget
+            wget \
+            yarn
 
 # Install system dependencies
 RUN     apk add --no-cache \
@@ -49,13 +50,18 @@ RUN     set -o pipefail && \
         git verify-commit ${GROCY_VERSION} && \
         rm -rf ${GNUPGHOME}
 
+# Install application dependencies
+RUN     yarn install --modules-folder /var/www/public/node_modules --production && \
+        yarn cache clean
+
 # Remove build-time dependencies (privileged)
 USER root
 RUN     apk del \
             openssl \
             git \
             gnupg \
-            wget
+            wget \
+            yarn
 
 VOLUME ["/var/log/nginx"]
 

--- a/Dockerfile-grocy-nginx
+++ b/Dockerfile-grocy-nginx
@@ -31,6 +31,10 @@ COPY docker_nginx/common.conf /etc/nginx/common.conf
 COPY docker_nginx/conf.d/default.conf /etc/nginx/conf.d/default.conf
 COPY docker_nginx/conf.d/ssl.conf /etc/nginx/conf.d/ssl.conf
 
+# Remove build-time dependencies
+RUN     apk del \
+            openssl
+
 VOLUME ["/var/log/nginx"]
 
 EXPOSE 8080 8443

--- a/Dockerfile-grocy-nginx
+++ b/Dockerfile-grocy-nginx
@@ -1,6 +1,8 @@
 FROM alpine:3.11.5
 LABEL maintainer "Talmai Oliveira <to@talm.ai>, James Addison <jay@jp-hosting.net>"
 
+ARG GROCY_VERSION
+
 RUN     apk add --no-cache \
             openssl \
             nginx && \

--- a/Dockerfile-grocy-nginx
+++ b/Dockerfile-grocy-nginx
@@ -36,7 +36,21 @@ COPY docker_nginx/common.conf /etc/nginx/common.conf
 COPY docker_nginx/conf.d/default.conf /etc/nginx/conf.d/default.conf
 COPY docker_nginx/conf.d/ssl.conf /etc/nginx/conf.d/ssl.conf
 
-# Remove build-time dependencies
+# Install application dependencies (unprivileged)
+USER nginx
+WORKDIR /var/www
+
+# Extract application release package
+ENV GROCY_RELEASE_KEY_URI="https://berrnd.de/data/Bernd_Bestel.asc"
+RUN     set -o pipefail && \
+        export GNUPGHOME=$(mktemp -d) && \
+        wget ${GROCY_RELEASE_KEY_URI} -O - | gpg --batch --import && \
+        git clone --branch ${GROCY_VERSION} --config advice.detachedHead=false --depth 1 "https://github.com/grocy/grocy.git" . && \
+        git verify-commit ${GROCY_VERSION} && \
+        rm -rf ${GNUPGHOME}
+
+# Remove build-time dependencies (privileged)
+USER root
 RUN     apk del \
             openssl \
             git \

--- a/Makefile
+++ b/Makefile
@@ -36,5 +36,5 @@ grocy:
 	podman tag $@:${IMAGE_TAG} $@:latest
 
 nginx:
-	podman image exists $@:${IMAGE_TAG} || buildah bud -f Dockerfile-grocy-nginx -t $@:${IMAGE_TAG} .
+	podman image exists $@:${IMAGE_TAG} || buildah bud --build-arg GROCY_VERSION=${GROCY_VERSION} -f Dockerfile-grocy-nginx -t $@:${IMAGE_TAG} .
 	podman tag $@:${IMAGE_TAG} $@:latest

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,6 @@ build: pod grocy nginx
         --read-only \
         --volume /var/log/php7 \
         --volume app-db:/var/www/data \
-        --volume www-static:/var/www/public:ro \
         grocy:${IMAGE_TAG}
 	podman run \
         --add-host grocy:127.0.0.1 \
@@ -24,7 +23,6 @@ build: pod grocy nginx
         --read-only \
         --tmpfs /tmp \
         --volume /var/log/nginx \
-        --volume www-static:/var/www/public:ro \
         nginx:${IMAGE_TAG}
 
 pod:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,8 @@ services:
   nginx:
     image: "grocy/nginx:v2.6.2-3"
     build:
+      args:
+        GROCY_VERSION: v2.6.2
       context: .
       dockerfile: Dockerfile-grocy-nginx
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,6 @@ services:
       - /tmp
     volumes:
       - /var/log/nginx
-      - www-static:/var/www/public:ro
     container_name: nginx
 
   grocy:
@@ -38,11 +37,9 @@ services:
     volumes:
       - /var/log/php7
       - app-db:/var/www/data
-      - www-static:/var/www/public:ro
     env_file:
       - grocy.env
     container_name: grocy
 
 volumes:
   app-db:
-  www-static:


### PR DESCRIPTION
So far the `grocy/grocy` and `grocy/nginx` containers have relied upon a shared `www-static` volume that contains JavaScript, images and other static web content to be served by `nginx`.

Shared dependencies like this (`bind` mounts in `docker-compose` terminology, `ReadOnlyMany` persistent volumes in Kubernetes terminology) introduce the potential for container-to-host code and I/O dependencies, even when mounted read-only.

This changeset unpacks the static web content into the `grocy/nginx` container image at build-time. 