### PR TITLE
Prepare release containing grocy v2.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- Upgrade to grocy release v2.7.0
+
 ## [v2.6.2-4] - 2020-04-07
 
 ### Removed

--- a/Dockerfile-grocy
+++ b/Dockerfile-grocy
@@ -68,6 +68,10 @@ RUN     COMPOSER_OAUTH=${GITHUB_API_TOKEN:+"\"github.com\": \"${GITHUB_API_TOKEN
         COMPOSER_AUTH="{\"github-oauth\": { ${COMPOSER_OAUTH} }}" composer install --no-interaction --no-dev --optimize-autoloader && \
         composer clear-cache
 
+# Workaround: create node_modules directory
+# See: https://github.com/grocy/grocy/issues/744
+RUN     touch /var/www/public/node_modules
+
 # Remove build-time dependencies (privileged)
 USER root
 RUN     apk del \

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: build pod grocy nginx
 
-GROCY_VERSION = v2.6.2
+GROCY_VERSION = v2.7.0
 IMAGE_COMMIT := $(shell git rev-parse --short HEAD)
 IMAGE_TAG := $(strip $(if $(shell git status --porcelain --untracked-files=no), "${IMAGE_COMMIT}-dirty", "${IMAGE_COMMIT}"))
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,10 +3,10 @@ version: '2.4'
 services:
 
   nginx:
-    image: "grocy/nginx:v2.6.2-4"
+    image: "grocy/nginx:v2.7.0-1"
     build:
       args:
-        GROCY_VERSION: v2.6.2
+        GROCY_VERSION: v2.7.0
       context: .
       dockerfile: Dockerfile-grocy-nginx
     depends_on:
@@ -22,11 +22,11 @@ services:
     container_name: nginx
 
   grocy:
-    image: "grocy/grocy:v2.6.2-4"
+    image: "grocy/grocy:v2.7.0-1"
     build:
       args:
         GITHUB_API_TOKEN: "${GITHUB_API_TOKEN}"
-        GROCY_VERSION: v2.6.2
+        GROCY_VERSION: v2.7.0
       context: .
       dockerfile: Dockerfile-grocy
     expose:


### PR DESCRIPTION
Prepare a `grocy-docker` release corresponding to [grocy v2.7.0](https://github.com/grocy/grocy/releases/tag/v2.7.0).