### PR TITLE
Prepare release containing grocy v2.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-###
+### Added
 
 - Upgrade to grocy release v2.7.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+###
+
+- Upgrade to grocy release v2.7.1
+
 ## [v2.7.0-1] - 2020-04-17
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: build pod grocy nginx
 
-GROCY_VERSION = v2.7.0
+GROCY_VERSION = v2.7.1
 IMAGE_COMMIT := $(shell git rev-parse --short HEAD)
 IMAGE_TAG := $(strip $(if $(shell git status --porcelain --untracked-files=no), "${IMAGE_COMMIT}-dirty", "${IMAGE_COMMIT}"))
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,10 +3,10 @@ version: '2.4'
 services:
 
   nginx:
-    image: "grocy/nginx:v2.7.0-1"
+    image: "grocy/nginx:v2.7.1-1"
     build:
       args:
-        GROCY_VERSION: v2.7.0
+        GROCY_VERSION: v2.7.1
       context: .
       dockerfile: Dockerfile-grocy-nginx
     depends_on:
@@ -22,11 +22,11 @@ services:
     container_name: nginx
 
   grocy:
-    image: "grocy/grocy:v2.7.0-1"
+    image: "grocy/grocy:v2.7.1-1"
     build:
       args:
         GITHUB_API_TOKEN: "${GITHUB_API_TOKEN}"
-        GROCY_VERSION: v2.7.0
+        GROCY_VERSION: v2.7.1
       context: .
       dockerfile: Dockerfile-grocy
     expose:


### PR DESCRIPTION
Prepare a `grocy-docker` release corresponding to grocy [v2.7.1](https://github.com/grocy/grocy/releases/tag/v2.7.1).