### PR TITLE
Remove node_modules existence check workaround

### DIFF
--- a/Dockerfile-grocy
+++ b/Dockerfile-grocy
@@ -68,10 +68,6 @@ RUN     COMPOSER_OAUTH=${GITHUB_API_TOKEN:+"\"github.com\": \"${GITHUB_API_TOKEN
         COMPOSER_AUTH="{\"github-oauth\": { ${COMPOSER_OAUTH} }}" composer install --no-interaction --no-dev --optimize-autoloader && \
         composer clear-cache
 
-# Workaround: create node_modules directory
-# See: https://github.com/grocy/grocy/issues/744
-RUN     touch /var/www/public/node_modules
-
 # Remove build-time dependencies (privileged)
 USER root
 RUN     apk del \


### PR DESCRIPTION
This can be removed now that https://github.com/grocy/grocy/issues/744 is resolved.