### PR TITLE
Rebuild nginx image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [v2.7.1-2] - 2020-04-21
+
+### Changed
+
+- Rebuild nginx image with new Alpine 'openssl' package
+- Was: 'OpenSSL 1.1.1d  10 Sep 2019'
+- Now: 'OpenSSL 1.1.1g  21 Apr 2020 (Library: OpenSSL 1.1.1d  10 Sep 2019)'
+
 ## [v2.7.1-1] - 2020-04-18
 
 ### Added

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2.4'
 services:
 
   nginx:
-    image: "grocy/nginx:v2.7.1-1"
+    image: "grocy/nginx:v2.7.1-2"
     build:
       args:
         GROCY_VERSION: v2.7.1
@@ -22,7 +22,7 @@ services:
     container_name: nginx
 
   grocy:
-    image: "grocy/grocy:v2.7.1-1"
+    image: "grocy/grocy:v2.7.1-2"
     build:
       args:
         GITHUB_API_TOKEN: "${GITHUB_API_TOKEN}"


### PR DESCRIPTION
`grocy-docker` doesn't use `openssl` for any TLS negotiation, and in fact it only exists during build-time in the container layers, and is removed in the final image.  Thanks to that, I don't believe it should be vulnerable to [CVE-2020-1967](https://www.openssl.org/news/secadv/20200421.txt).

Even so, to avoid any potential false positives (vuln scanners, etc), it seems worthwhile to apply a quick version bump here since it's low effort.