### PR TITLE
Update images to Alpine 3.11.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+- Rebuild container images with new Alpine 3.11.6 release
+
 ## [v2.7.1-2] - 2020-04-21
 
 ### Changed

--- a/Dockerfile-grocy
+++ b/Dockerfile-grocy
@@ -1,4 +1,4 @@
-FROM alpine:3.11.5
+FROM alpine:3.11.6
 LABEL maintainer "Talmai Oliveira <to@talm.ai>, James Addison <jay@jp-hosting.net>"
 
 ARG GROCY_VERSION

--- a/Dockerfile-grocy-nginx
+++ b/Dockerfile-grocy-nginx
@@ -1,4 +1,4 @@
-FROM alpine:3.11.5
+FROM alpine:3.11.6
 LABEL maintainer "Talmai Oliveira <to@talm.ai>, James Addison <jay@jp-hosting.net>"
 
 ARG GROCY_VERSION

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2.4'
 services:
 
   nginx:
-    image: "grocy/nginx:v2.7.1-2"
+    image: "grocy/nginx:v2.7.1-3"
     build:
       args:
         GROCY_VERSION: v2.7.1
@@ -22,7 +22,7 @@ services:
     container_name: nginx
 
   grocy:
-    image: "grocy/grocy:v2.7.1-2"
+    image: "grocy/grocy:v2.7.1-3"
     build:
       args:
         GITHUB_API_TOKEN: "${GITHUB_API_TOKEN}"


### PR DESCRIPTION
See the [Alpine Linux 3.11.6 release notes](https://www.alpinelinux.org/posts/Alpine-3.11.6-released.html) for details.