### PR TITLE
Upgrade alpine 3.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+- Perform `apk update` prior to Alpine Linux package installation
+- Rebuild container images with new Alpine 3.12.0 release
+
 ## [v2.7.1-3] - 2020-04-27
 
 ### Changed

--- a/Dockerfile-grocy
+++ b/Dockerfile-grocy
@@ -1,4 +1,4 @@
-FROM alpine:3.11.6
+FROM alpine:3.12.0
 LABEL maintainer "Talmai Oliveira <to@talm.ai>, James Addison <jay@jp-hosting.net>"
 
 ARG GROCY_VERSION

--- a/Dockerfile-grocy
+++ b/Dockerfile-grocy
@@ -24,7 +24,8 @@ RUN set -eux; \
 # https://git.alpinelinux.org/aports/tree/main/nginx/nginx.pre-install?h=3.9-stable
 
 # Install build-time dependencies
-RUN     apk add --no-cache \
+RUN     apk update && \
+        apk add --no-cache \
             composer \
             git \
             gnupg \

--- a/Dockerfile-grocy-nginx
+++ b/Dockerfile-grocy-nginx
@@ -1,4 +1,4 @@
-FROM alpine:3.11.6
+FROM alpine:3.12.0
 LABEL maintainer "Talmai Oliveira <to@talm.ai>, James Addison <jay@jp-hosting.net>"
 
 ARG GROCY_VERSION

--- a/Dockerfile-grocy-nginx
+++ b/Dockerfile-grocy-nginx
@@ -12,7 +12,8 @@ RUN     apk add --no-cache \
             yarn
 
 # Install system dependencies
-RUN     apk add --no-cache \
+RUN     apk update && \
+        apk add --no-cache \
             nginx
 
 # Generate TLS certificates


### PR DESCRIPTION
See the [Alpine Linux 3.11.6 release notes](https://www.alpinelinux.org/posts/Alpine-3.12.0-released.html) for details.