### PR TITLE
gitattributes: add Dockerfile-* to Dockerfile linguist language

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+Dockerfile-* linguist-language=Dockerfile


### PR DESCRIPTION
Adds `Dockerfile-*` Files to the Dockerfile-language.

GitHub just mark files as this language if, it has the .dockerfile extension or the explicit name Dockerfile. [(View)](https://github.com/github/linguist/blob/master/lib/linguist/languages.yml#L1209)

This line in the `.gitattributes`-File will also mark `Dockerfile-*`-Files as Dockerfiles.
So, this repository will marked as a `Dockerfile`-Repository instead of `Makefile`