### PR TITLE
Grocy.env config incorrectly uses apostrophe in the example

### DIFF
--- a/grocy.env
+++ b/grocy.env
@@ -11,7 +11,7 @@
 #
 #       Setting('CURRENCY', 'USD');
 #
-# Then we would set GROCY_CURRENCY='EUR'. 
+# Then we would set GROCY_CURRENCY=EUR 
 
 
 ## User-supplied Variables


### PR DESCRIPTION
Using apostrophe in the config file causes an error when handling monetary values and causes the meal plan page to malfunction. Buttons on this page stop functionning.
This PR aims to change the documentation to not show an incorrect example.