### PR TITLE
node_modules fix

### DIFF
--- a/Dockerfile-grocy
+++ b/Dockerfile-grocy
@@ -1,6 +1,6 @@
 ARG PLATFORM
 
-FROM docker.io/alpine:3.13.1
+FROM --platform=${PLATFORM} docker.io/alpine:3.13.1
 LABEL maintainer "Talmai Oliveira <to@talm.ai>, James Addison <jay@jp-hosting.net>"
 
 ARG GROCY_VERSION

--- a/Dockerfile-grocy
+++ b/Dockerfile-grocy
@@ -1,6 +1,6 @@
 ARG PLATFORM
 
-FROM --platform=${PLATFORM} docker.io/alpine:3.13.1
+FROM docker.io/alpine:3.13.1
 LABEL maintainer "Talmai Oliveira <to@talm.ai>, James Addison <jay@jp-hosting.net>"
 
 ARG GROCY_VERSION
@@ -18,6 +18,7 @@ RUN set -eux; \
 RUN     apk update && \
         apk add --no-cache \
             composer \
+            yarn \
             git \
             gnupg \
             wget
@@ -60,12 +61,15 @@ RUN     set -o pipefail && \
 
 # Install application dependencies
 RUN     composer install --no-interaction --no-dev --optimize-autoloader && \
-        composer clear-cache
+        composer clear-cache && \
+        yarn install --modules-folder /var/www/public/node_modules --production && \
+        yarn cache clean
 
 # Remove build-time dependencies (privileged)
 USER root
 RUN     apk del \
             composer \
+            yarn \
             git \
             gnupg \
             wget


### PR DESCRIPTION
Fixes no node_modules folder in grocy/grocy

I tested it with a manual docker build, and that behaves as expected. Haven't tested the makefile as that has a bunch of dependencies I don't want to get into

Resolves #120 