### PR TITLE
Configure default PLATFORM argument in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
     build:
       args:
         GROCY_VERSION: v3.0.1
+        PLATFORM: linux/amd64
       context: .
       dockerfile: Dockerfile-grocy-nginx
     depends_on:
@@ -26,6 +27,7 @@ services:
     build:
       args:
         GROCY_VERSION: v3.0.1
+        PLATFORM: linux/amd64
       context: .
       dockerfile: Dockerfile-grocy
     expose:


### PR DESCRIPTION
Using linux/amd64 for backwards-compatibility with existing Docker Hub release images

Resolves #124 