### PR TITLE
Fix hostname of backend container

### DIFF
--- a/docker_frontend/common.conf
+++ b/docker_frontend/common.conf
@@ -9,7 +9,7 @@ location ~* .(jpg|jpeg|png|gif|ico|css|js)$ {
 }
 
 location ~ \.php$ {
-    fastcgi_pass   grocy:9000;
+    fastcgi_pass   backend:9000;
     fastcgi_index  index.php;
     fastcgi_param  SCRIPT_FILENAME  $document_root$fastcgi_script_name;
     include        fastcgi_params;


### PR DESCRIPTION
At the moment the frontend container crashes when using the docker-compose file provided in the repo, since the backend container name does not match the one in the configuration file.

This should fix it :smile: 