### PR TITLE
feat: Update to grocy v3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Use more meaningful container names
   - 'grocy/grocy' becomes 'grocy/backend'
   - 'grocy/nginx' becomes 'grocy/frontend'
+- Upgrade to grocy v3.1.0 and PHP8 (thank you, @HamburgerJungeJr)
 
 ## [v3.0.1-12] - 2021-07-18
 

--- a/Dockerfile-grocy-backend
+++ b/Dockerfile-grocy-backend
@@ -4,6 +4,8 @@ FROM --platform=${PLATFORM} docker.io/alpine:3.14.0
 LABEL maintainer "Talmai Oliveira <to@talm.ai>, James Addison <jay@jp-hosting.net>"
 
 ARG GROCY_VERSION
+ARG COMPOSER_VERSION
+ARG COMPOSER_CHECKSUM
 
 # ensure www-data user exists
 RUN set -eux; \
@@ -16,31 +18,40 @@ RUN set -eux; \
 # Install build-time dependencies
 RUN     apk update && \
         apk add --no-cache \
-            composer \
             git \
             gnupg \
             wget
 
 # Install system dependencies
 RUN     apk add --no-cache \
-            php7-ctype \
-            php7-fpm \
-            php7-exif \
-            php7-fileinfo \
-            php7-gd \
-            php7-iconv \
-            php7-json \
-            php7-ldap \
-            php7-pdo_sqlite \
-            php7-simplexml \
-            php7-tokenizer
+            php8 \
+            php8-ctype \
+            php8-fpm \
+            php8-exif \
+            php8-fileinfo \
+            php8-gd \
+            php8-iconv \
+            php8-ldap \
+            php8-pdo_sqlite \
+            php8-simplexml \
+            php8-tokenizer \
+            php8-phar \
+            php8-curl \
+            php8-mbstring \
+            php8-openssl \
+            php8-zip \
+            php8-intl && \
+        ln -s /usr/bin/php8 /usr/bin/php && \
+        wget https://getcomposer.org/download/${COMPOSER_VERSION}/composer.phar -O /tmp/composer.phar && \
+        echo "${COMPOSER_CHECKSUM}  /tmp/composer.phar" | sha256sum -c - && \
+        mv /tmp/composer.phar /usr/bin/composer && chmod +x /usr/bin/composer
 
 # Configure directory permissions
-RUN     chown www-data /var/log/php7 && \
+RUN     chown www-data /var/log/php8 && \
         mkdir /var/www && \
         chown www-data /var/www
 
-COPY docker_backend/www.conf /etc/php7/php-fpm.d/zz-docker.conf
+COPY docker_backend/www.conf /etc/php8/php-fpm.d/zz-docker.conf
 
 # Install application dependencies (unprivileged)
 USER www-data
@@ -64,7 +75,6 @@ RUN     composer install --no-interaction --no-dev --optimize-autoloader && \
 # Remove build-time dependencies (privileged)
 USER root
 RUN     apk del \
-            composer \
             git \
             gnupg \
             wget
@@ -75,4 +85,4 @@ EXPOSE 9000
 
 USER www-data
 
-CMD ["php-fpm7"]
+CMD ["php-fpm8"]

--- a/Dockerfile-grocy-backend
+++ b/Dockerfile-grocy-backend
@@ -40,9 +40,17 @@ RUN     apk add --no-cache \
             php8-mbstring \
             php8-openssl \
             php8-zip \
-            php8-intl && \
-        ln -s /usr/bin/php8 /usr/bin/php && \
-        wget https://getcomposer.org/download/${COMPOSER_VERSION}/composer.phar -O /tmp/composer.phar && \
+            php8-intl
+
+# Link /usr/bin/php to /usr/bin/php8 for universall access to latest php binary. 
+# Required by composer, possibly needed by grocy
+RUN     ln -s /usr/bin/php8 /usr/bin/php
+
+# Manually install composer.
+# As php7 is still the default php version on alpine installing alpine-composer-package would install php7 an add link from /usr/bin/php to /usr/bin/php7.
+# This might conflict with grocy if grocy depends on /usr/bin/php linking to /usr/bin/php8
+# See: https://gitlab.alpinelinux.org/alpine/aports/-/issues/12308
+RUN     wget https://getcomposer.org/download/${COMPOSER_VERSION}/composer.phar -O /tmp/composer.phar && \
         echo "${COMPOSER_CHECKSUM}  /tmp/composer.phar" | sha256sum -c - && \
         mv /tmp/composer.phar /usr/bin/composer && chmod +x /usr/bin/composer
 

--- a/Dockerfile-grocy-backend
+++ b/Dockerfile-grocy-backend
@@ -42,13 +42,10 @@ RUN     apk add --no-cache \
             php8-zip \
             php8-intl
 
-# Link /usr/bin/php to /usr/bin/php8 for universall access to latest php binary. 
-# Required by composer, possibly needed by grocy
+# Configure PHP8 as the system default (for composer and grocy)
 RUN     ln -s /usr/bin/php8 /usr/bin/php
 
-# Manually install composer.
-# As php7 is still the default php version on alpine installing alpine-composer-package would install php7 an add link from /usr/bin/php to /usr/bin/php7.
-# This might conflict with grocy if grocy depends on /usr/bin/php linking to /usr/bin/php8
+# Install composer from source instead of using (php7-dependent) Alpine Linux package
 # See: https://gitlab.alpinelinux.org/alpine/aports/-/issues/12308
 RUN     wget https://getcomposer.org/download/${COMPOSER_VERSION}/composer.phar -O /tmp/composer.phar && \
         echo "${COMPOSER_CHECKSUM}  /tmp/composer.phar" | sha256sum -c - && \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     image: "grocy/frontend:${GROCY_IMAGE_TAG}"
     build:
       args:
-        GROCY_VERSION: v3.0.1
+        GROCY_VERSION: v3.1.0
         PLATFORM: linux/amd64
       context: .
       dockerfile: Dockerfile-grocy-frontend
@@ -25,8 +25,10 @@ services:
     image: "grocy/backend:${GROCY_IMAGE_TAG}"
     build:
       args:
-        GROCY_VERSION: v3.0.1
+        GROCY_VERSION: v3.1.0
         PLATFORM: linux/amd64
+        COMPOSER_VERSION: "2.1.5"
+        COMPOSER_CHECKSUM: "be95557cc36eeb82da0f4340a469bad56b57f742d2891892dcb2f8b0179790ec"
       context: .
       dockerfile: Dockerfile-grocy-backend
     expose:
@@ -35,7 +37,7 @@ services:
     tmpfs:
       - /tmp
     volumes:
-      - /var/log/php7
+      - /var/log/php8
       - app-db:/var/www/data
     env_file:
       - grocy.env


### PR DESCRIPTION
Hi,

I updates the dockerfile to run grocy v3.1.0. 
I was able to build the image locally and run grocy.

I installed composer manually to the image and added the necessary php8-dependencies.
Also I added two new args to set the composer version as well as the corresponding SHA256-Hash of composer.

Please have a look, especially at the makefile as I'm not very experienced with them.