### PR TITLE
Upgrade to grocy v3.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Unreleased]
+
+- Upgrade to grocy v3.1.1
+
 ## [v3.1.0-0] - 2021-08-21
 
 - Rebuild container images with Alpine 3.14.0

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: build pod manifest manifest-create %-backend %-frontend
 
-GROCY_VERSION = v3.1.0
+GROCY_VERSION = v3.1.1
 COMPOSER_VERSION = 2.1.5
 COMPOSER_CHECKSUM = be95557cc36eeb82da0f4340a469bad56b57f742d2891892dcb2f8b0179790ec
 IMAGE_COMMIT := $(shell git rev-parse --short HEAD)

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Follow [these instructions](https://docs.docker.com/install/) to get Docker runn
 To get started using pre-built [Docker Hub grocy images](https://hub.docker.com/u/grocy), run the following commands:
 
 ```sh
-export GROCY_IMAGE_TAG=v3.1.0-0
+export GROCY_IMAGE_TAG=v3.1.1-0
 docker-compose pull
 docker-compose up
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     image: "grocy/frontend:${GROCY_IMAGE_TAG}"
     build:
       args:
-        GROCY_VERSION: v3.1.0
+        GROCY_VERSION: v3.1.1
         PLATFORM: linux/amd64
       context: .
       dockerfile: Dockerfile-grocy-frontend

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "name": "grocy-docker",
-  "version": "3.1.0-0",
+  "version": "3.1.1-0",
   "description": "ERP beyond your fridge - now containerized",
   "main": ".",
   "scripts": {
     "build": "docker-compose build",
     "test": "npm run build && npm run test:grocy && npm run test:nginx",
-    "test:backend": "npx snyk test --docker grocy/backend:v3.1.0-0 --file=Dockerfile-grocy-backend",
-    "test:frontend": "npx snyk test --docker grocy/frontend:v3.1.0-0 --file=Dockerfile-grocy-frontend"
+    "test:backend": "npx snyk test --docker grocy/backend:v3.1.1-0 --file=Dockerfile-grocy-backend",
+    "test:frontend": "npx snyk test --docker grocy/frontend:v3.1.1-0 --file=Dockerfile-grocy-frontend"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Upgrade to today's release of [`grocy` v3.1.1](https://github.com/grocy/grocy/releases/tag/v3.1.1).