### PR TITLE
Set correct GROCY_VERSION for backend

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
     image: "grocy/backend:${GROCY_IMAGE_TAG}"
     build:
       args:
-        GROCY_VERSION: v3.1.0
+        GROCY_VERSION: v3.1.1
         PLATFORM: linux/amd64
         COMPOSER_VERSION: "2.1.5"
         COMPOSER_CHECKSUM: "be95557cc36eeb82da0f4340a469bad56b57f742d2891892dcb2f8b0179790ec"


### PR DESCRIPTION
This probably should have happened in f2d4783fd977e3fce4485c54c3b8b67c6978bbe9.