### PR TITLE
Podman run without build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [Unreleased]
+
+- Changes to the Makefile
+  - The `build` target now only builds the image, but does not start it.
+  - The `create` target (re)creates a pod for grocy, but does not start it.
+  - The `run` target depends on `create` and then starts the created pod.
+  - The host prefixes of the images are now set to match the official images on Docker hub and can be overriden using the IMAGE_PREFIX variable.
+  - The image tags are now generated from `git describe`, but can be overridden using the IMAGE_TAG variable.
+
 ## [v3.1.1-1] - 2021-09-02
 
 - Fixup: use correct GROCY_VERSION (v3.1.1) for backend in docker-compose.yml (thank you, @Kritzefitz)

--- a/Makefile
+++ b/Makefile
@@ -10,10 +10,9 @@ PLATFORM ?= linux/386 linux/amd64 linux/arm/v6 linux/arm/v7 linux/arm64/v8 linux
 
 build: manifest
 
-run: pod
-	podman run \
+create: pod
+	podman create \
         --add-host grocy:127.0.0.1 \
-        --detach \
         --env-file grocy.env \
         --name backend \
         --pod grocy-pod \
@@ -21,15 +20,17 @@ run: pod
         --volume /var/log/php8 \
         --volume app-db:/var/www/data \
         ${IMAGE_PREFIX}/backend:${IMAGE_TAG}
-	podman run \
+	podman create \
         --add-host grocy:127.0.0.1 \
-        --detach \
         --name frontend \
         --pod grocy-pod \
         --read-only \
         --tmpfs /tmp \
         --volume /var/log/nginx \
         ${IMAGE_PREFIX}/frontend:${IMAGE_TAG}
+
+run: create
+	podman pod start grocy-pod
 
 pod:
 	podman pod rm -f grocy-pod || true

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ GROCY_VERSION = v3.1.1
 COMPOSER_VERSION = 2.1.5
 COMPOSER_CHECKSUM = be95557cc36eeb82da0f4340a469bad56b57f742d2891892dcb2f8b0179790ec
 IMAGE_COMMIT := $(shell git rev-parse --short HEAD)
-IMAGE_TAG := $(strip $(if $(shell git status --porcelain --untracked-files=no), "${IMAGE_COMMIT}-dirty", "${IMAGE_COMMIT}"))
+IMAGE_TAG ?= $(strip $(if $(shell git status --porcelain --untracked-files=no), "${IMAGE_COMMIT}-dirty", "${IMAGE_COMMIT}"))
 
 IMAGE_PREFIX ?= docker.io/grocy
 PLATFORM ?= linux/386 linux/amd64 linux/arm/v6 linux/arm/v7 linux/arm64/v8 linux/ppc64le linux/s390x

--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,7 @@
 GROCY_VERSION = v3.1.1
 COMPOSER_VERSION = 2.1.5
 COMPOSER_CHECKSUM = be95557cc36eeb82da0f4340a469bad56b57f742d2891892dcb2f8b0179790ec
-IMAGE_COMMIT := $(shell git rev-parse --short HEAD)
-IMAGE_TAG ?= $(strip $(if $(shell git status --porcelain --untracked-files=no), "${IMAGE_COMMIT}-dirty", "${IMAGE_COMMIT}"))
+IMAGE_TAG ?= $(shell git describe --tags --match 'v*' --dirty)
 
 IMAGE_PREFIX ?= docker.io/grocy
 PLATFORM ?= linux/386 linux/amd64 linux/arm/v6 linux/arm/v7 linux/arm64/v8 linux/ppc64le linux/s390x

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build pod manifest manifest-create %-backend %-frontend
+.PHONY: build run pod manifest manifest-create %-backend %-frontend
 
 GROCY_VERSION = v3.1.1
 COMPOSER_VERSION = 2.1.5
@@ -9,7 +9,9 @@ IMAGE_TAG := $(strip $(if $(shell git status --porcelain --untracked-files=no), 
 IMAGE_PREFIX ?= docker.io/grocy
 PLATFORM ?= linux/386 linux/amd64 linux/arm/v6 linux/arm/v7 linux/arm64/v8 linux/ppc64le linux/s390x
 
-build: pod manifest
+build: manifest run
+
+run: pod
 	podman run \
         --add-host grocy:127.0.0.1 \
         --detach \

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ IMAGE_TAG ?= $(shell git describe --tags --match 'v*' --dirty)
 IMAGE_PREFIX ?= docker.io/grocy
 PLATFORM ?= linux/386 linux/amd64 linux/arm/v6 linux/arm/v7 linux/arm64/v8 linux/ppc64le linux/s390x
 
-build: manifest run
+build: manifest
 
 run: pod
 	podman run \

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ COMPOSER_CHECKSUM = be95557cc36eeb82da0f4340a469bad56b57f742d2891892dcb2f8b01797
 IMAGE_COMMIT := $(shell git rev-parse --short HEAD)
 IMAGE_TAG := $(strip $(if $(shell git status --porcelain --untracked-files=no), "${IMAGE_COMMIT}-dirty", "${IMAGE_COMMIT}"))
 
+IMAGE_PREFIX ?= docker.io/grocy
 PLATFORM ?= linux/386 linux/amd64 linux/arm/v6 linux/arm/v7 linux/arm64/v8 linux/ppc64le linux/s390x
 
 build: pod manifest
@@ -18,7 +19,7 @@ build: pod manifest
         --read-only \
         --volume /var/log/php8 \
         --volume app-db:/var/www/data \
-        backend:${IMAGE_TAG}
+        ${IMAGE_PREFIX}/backend:${IMAGE_TAG}
 	podman run \
         --add-host grocy:127.0.0.1 \
         --detach \
@@ -27,7 +28,7 @@ build: pod manifest
         --read-only \
         --tmpfs /tmp \
         --volume /var/log/nginx \
-        frontend:${IMAGE_TAG}
+        ${IMAGE_PREFIX}/frontend:${IMAGE_TAG}
 
 pod:
 	podman pod rm -f grocy-pod || true
@@ -36,17 +37,17 @@ pod:
 manifest: manifest-create $(PLATFORM)
 
 manifest-create:
-	buildah rmi -f backend:${IMAGE_TAG} || true
-	buildah rmi -f frontend:${IMAGE_TAG} || true
-	buildah manifest create backend:${IMAGE_TAG}
-	buildah manifest create frontend:${IMAGE_TAG}
+	buildah rmi -f ${IMAGE_PREFIX}/backend:${IMAGE_TAG} || true
+	buildah rmi -f ${IMAGE_PREFIX}/frontend:${IMAGE_TAG} || true
+	buildah manifest create ${IMAGE_PREFIX}/backend:${IMAGE_TAG}
+	buildah manifest create ${IMAGE_PREFIX}/frontend:${IMAGE_TAG}
 
 $(PLATFORM): %: %-backend %-frontend
 
-%-backend: GROCY_IMAGE = $(shell buildah bud --build-arg GROCY_VERSION=${GROCY_VERSION} --build-arg COMPOSER_VERSION=${COMPOSER_VERSION} --build-arg COMPOSER_CHECKSUM=${COMPOSER_CHECKSUM} --build-arg PLATFORM=$* --file Dockerfile-grocy-backend --platform $* --quiet --tag backend/$*:${IMAGE_TAG})
+%-backend: GROCY_IMAGE = $(shell buildah bud --build-arg GROCY_VERSION=${GROCY_VERSION} --build-arg COMPOSER_VERSION=${COMPOSER_VERSION} --build-arg COMPOSER_CHECKSUM=${COMPOSER_CHECKSUM} --build-arg PLATFORM=$* --file Dockerfile-grocy-backend --platform $* --quiet --tag ${IMAGE_PREFIX}/backend/$*:${IMAGE_TAG})
 %-backend:
-	buildah manifest add backend:${IMAGE_TAG} ${GROCY_IMAGE}
+	buildah manifest add ${IMAGE_PREFIX}/backend:${IMAGE_TAG} ${GROCY_IMAGE}
 
-%-frontend: NGINX_IMAGE = $(shell buildah bud --build-arg GROCY_VERSION=${GROCY_VERSION} --build-arg COMPOSER_VERSION=${COMPOSER_VERSION} --build-arg COMPOSER_CHECKSUM=${COMPOSER_CHECKSUM} --build-arg PLATFORM=$* --file Dockerfile-grocy-frontend --platform $* --quiet --tag frontend/$*:${IMAGE_TAG})
+%-frontend: NGINX_IMAGE = $(shell buildah bud --build-arg GROCY_VERSION=${GROCY_VERSION} --build-arg COMPOSER_VERSION=${COMPOSER_VERSION} --build-arg COMPOSER_CHECKSUM=${COMPOSER_CHECKSUM} --build-arg PLATFORM=$* --file Dockerfile-grocy-frontend --platform $* --quiet --tag ${IMAGE_PREFIX}/frontend/$*:${IMAGE_TAG})
 %-frontend:
-	buildah manifest add frontend:${IMAGE_TAG} ${NGINX_IMAGE}
+	buildah manifest add ${IMAGE_PREFIX}/frontend:${IMAGE_TAG} ${NGINX_IMAGE}


### PR DESCRIPTION
This makes some changes to the Makefile to integrate better with the official images on Docker Hub. The most prominent goal I had in mind, while making these changes, was being able to use `make run` to set up podman to pull the images from Docker Hub and run them appropriately. As a side feature it is now possible to use the Makefile to build images that can then be pushed to Docker Hub matching the schema for naming and tagging of images.

These are the individual changes done:

 * The functionality to run a grocy as a pod in podman has been split from `make build` to `make run`. The main difference is that `make run` doesn't depend on `make manifest`. It is mostly intended to be able to run an image without building it beforehand, instead relying on a previously build images or images that can be pulled from a registry. `make build` is now just a dummy target that depends on `manifest` and `run`.
 * An `IMAGE_PREFIX` can be passed to `make` to specify an explicit prefix for the image name. The default is set to `docker.io/grocy` to match the name of the official builds. But if desired you can also specify a completely different image name such as `my.awesome/registry`.
 * The `IMAGE_TAG` is now generated using `git describe`. This has the main advantage that is uses the git tag as the `IMAGE_TAG` if one is set on the current commit. Commits without a tag are identified in relation to the previous tag and their commit id.
 * The `IMAGE_TAG` can be explicitly overridden. This is mostly useful for `make run` to run another tag than `git describe` determines. But it could also be useful when building images with different tags.