### PR TITLE
Configurable Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ BACKEND_CONTAINER_NAME ?= grocy-backend
 FRONTEND_CONTAINER_NAME ?= grocy-frontend
 POD_NAME ?= grocy-pod
 APP_DB_VOLUME_NAME ?= grocy-app-db
+PUBLISH_AT ?= 127.0.0.1:8080
 
 PLATFORM ?= linux/386 linux/amd64 linux/arm/v6 linux/arm/v7 linux/arm64/v8 linux/ppc64le linux/s390x
 
@@ -42,7 +43,7 @@ run: create
 
 pod:
 	podman pod rm -f ${POD_NAME} || true
-	podman pod create --name ${POD_NAME} --publish 127.0.0.1:8080:8080
+	podman pod create --name ${POD_NAME} --publish "${PUBLISH_AT}:8080"
 
 manifest: manifest-create $(PLATFORM)
 

--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,6 @@ COMPOSER_VERSION = 2.1.5
 COMPOSER_CHECKSUM = be95557cc36eeb82da0f4340a469bad56b57f742d2891892dcb2f8b0179790ec
 IMAGE_TAG ?= $(shell git describe --tags --match 'v*' --dirty)
 IMAGE_PREFIX ?= docker.io/grocy
-BACKEND_CONTAINER_NAME ?= grocy-backend
-FRONTEND_CONTAINER_NAME ?= grocy-frontend
 POD_NAME ?= grocy-pod
 APP_DB_VOLUME_NAME ?= grocy-app-db
 PUBLISH_AT ?= 127.0.0.1:8080
@@ -21,7 +19,6 @@ create: pod
         --add-host frontend:127.0.0.1 \
         --add-host backend:127.0.0.1 \
         --env-file grocy.env \
-        --name "${BACKEND_CONTAINER_NAME}" \
         --pod "${POD_NAME}" \
         --read-only \
         --volume /var/log/php8 \
@@ -31,7 +28,6 @@ create: pod
         --add-host grocy:127.0.0.1 \
         --add-host frontend:127.0.0.1 \
         --add-host backend:127.0.0.1 \
-        --name "${FRONTEND_CONTAINER_NAME}" \
         --pod "${POD_NAME}" \
         --read-only \
         --tmpfs /tmp \

--- a/Makefile
+++ b/Makefile
@@ -5,10 +5,10 @@ COMPOSER_VERSION = 2.1.5
 COMPOSER_CHECKSUM = be95557cc36eeb82da0f4340a469bad56b57f742d2891892dcb2f8b0179790ec
 IMAGE_TAG ?= $(shell git describe --tags --match 'v*' --dirty)
 IMAGE_PREFIX ?= docker.io/grocy
-BACKEND_CONTAINER_NAME ?= backend
-FRONTEND_CONTAINER_NAME ?= frontend
+BACKEND_CONTAINER_NAME ?= grocy-backend
+FRONTEND_CONTAINER_NAME ?= grocy-frontend
 POD_NAME ?= grocy-pod
-APP_DB_VOLUME_NAME ?= app-db
+APP_DB_VOLUME_NAME ?= grocy-app-db
 
 PLATFORM ?= linux/386 linux/amd64 linux/arm/v6 linux/arm/v7 linux/arm64/v8 linux/ppc64le linux/s390x
 


### PR DESCRIPTION
While working on #141 I had some ideas for further changes. But I didn't want to bloat the scope of that pull request further. So here they are (or will be, when I'm finished).

The Makefile uses various names or values that don't affect the inner workings of the grocy containers. We can make them configurable without much trouble, by using overridable variables for them. The cases I identified that should be configurable are:

* [x] Container names (currently `frontend` and `backend`)
* [x] The name of the pod (currently `grocy-pod`)
* [x] The name of the volume (currently `app-db`)
* [x] The endpoint for the published port (currently `127.0.0.1:80808`)

I also noticed that some of the current names don't convey any relation to grocy, e.g. `fontend` could be a frontend for anything. Unfortunately podman doesn't namespace containers or volumes by the pod they belong to, so these names all end up in a namespace global to the whole podman instance. I would like to change the defaults to convey the relation to grocy:

* `frontend` -> `grocy-frontend`
* `backend` -> `grocy-backend`
* `app-db` -> `grocy-app-db`

Ideally, when these changes are merged, you should be able to run multiple grocy instances on the same podman instance without collisions by using different names for all instances.