### PR TITLE
Update package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "grocy-docker",
-  "version": "3.0.1",
+  "version": "3.1.1-1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "3.0.1",
+      "version": "3.1.1-1",
       "license": "MIT",
       "devDependencies": {
         "snyk": "^1.663.0"


### PR DESCRIPTION
As mentioned in #109, it'd be nice to find a way to keep this file automatically in-sync.  Common practice from various repositories and projects seems to be that developers build and then commit their lockfiles, although I often wonder whether that genuinely results in reproducible/consistent lockfiles.