### PR TITLE
Fixup & cleanup: podman create hostnames

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ create: pod
         --volume app-db:/var/www/data \
         ${IMAGE_PREFIX}/backend:${IMAGE_TAG}
 	podman create \
+        --add-host backend:127.0.0.1 \
         --name frontend \
         --pod grocy-pod \
         --read-only \

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,6 @@ build: manifest
 
 create: pod
 	podman create \
-        --add-host grocy:127.0.0.1 \
         --env-file grocy.env \
         --name backend \
         --pod grocy-pod \
@@ -21,7 +20,6 @@ create: pod
         --volume app-db:/var/www/data \
         ${IMAGE_PREFIX}/backend:${IMAGE_TAG}
 	podman create \
-        --add-host grocy:127.0.0.1 \
         --name frontend \
         --pod grocy-pod \
         --read-only \


### PR DESCRIPTION
These hostname mappings were, if I remember correctly, created to mirror the behaviour of `docker` with the `docker-compose` file (where each named container entry would be available as a resolvable hostname at runtime).

The only hostname resolution that I believe we need at runtime is for the `frontend` host to be able to resolve the location of the `backend` host so that the [`nginx` config can configure `fastcgi` passthrough](https://github.com/grocy/grocy-docker/blob/a502178e8c82cb45fb048f5b8def34f437c1daca/docker_frontend/common.conf#L12).