### PR TITLE
Upgrade to grocy v3.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Upgrade to grocy v3.1.2
 - Changes to the Makefile
   - The `build` target now only builds the image, but does not start it.
   - The `create` target (re)creates a pod for grocy, but does not start it.

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: build run pod manifest manifest-create %-backend %-frontend
 
-GROCY_VERSION = v3.1.1
+GROCY_VERSION = v3.1.2
 COMPOSER_VERSION = 2.1.5
 COMPOSER_CHECKSUM = be95557cc36eeb82da0f4340a469bad56b57f742d2891892dcb2f8b0179790ec
 IMAGE_TAG ?= $(shell git describe --tags --match 'v*' --dirty)

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Follow [these instructions](https://docs.docker.com/install/) to get Docker runn
 To get started using pre-built [Docker Hub grocy images](https://hub.docker.com/u/grocy), run the following commands:
 
 ```sh
-export GROCY_IMAGE_TAG=v3.1.1-1
+export GROCY_IMAGE_TAG=v3.1.2-0
 docker-compose pull
 docker-compose up
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     image: "grocy/frontend:${GROCY_IMAGE_TAG}"
     build:
       args:
-        GROCY_VERSION: v3.1.1
+        GROCY_VERSION: v3.1.2
         PLATFORM: linux/amd64
       context: .
       dockerfile: Dockerfile-grocy-frontend
@@ -25,7 +25,7 @@ services:
     image: "grocy/backend:${GROCY_IMAGE_TAG}"
     build:
       args:
-        GROCY_VERSION: v3.1.1
+        GROCY_VERSION: v3.1.2
         PLATFORM: linux/amd64
         COMPOSER_VERSION: "2.1.5"
         COMPOSER_CHECKSUM: "be95557cc36eeb82da0f4340a469bad56b57f742d2891892dcb2f8b0179790ec"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "grocy-docker",
-  "version": "3.0.1",
+  "version": "3.1.1-1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "3.0.1",
+      "version": "3.1.1-1",
       "license": "MIT",
       "devDependencies": {
         "snyk": "^1.663.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "grocy-docker",
-  "version": "3.1.1-1",
+  "version": "3.1.2-0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "3.1.1-1",
+      "version": "3.1.2-0",
       "license": "MIT",
       "devDependencies": {
         "snyk": "^1.663.0"

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "name": "grocy-docker",
-  "version": "3.1.1-1",
+  "version": "3.1.2-0",
   "description": "ERP beyond your fridge - now containerized",
   "main": ".",
   "scripts": {
     "build": "docker-compose build",
     "test": "npm run build && npm run test:grocy && npm run test:nginx",
-    "test:backend": "npx snyk test --docker grocy/backend:v3.1.1-1 --file=Dockerfile-grocy-backend",
-    "test:frontend": "npx snyk test --docker grocy/frontend:v3.1.1-1 --file=Dockerfile-grocy-frontend"
+    "test:backend": "npx snyk test --docker grocy/backend:v3.1.2-0 --file=Dockerfile-grocy-backend",
+    "test:frontend": "npx snyk test --docker grocy/frontend:v3.1.2-0 --file=Dockerfile-grocy-frontend"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Upgrade to today's release of [`grocy` v3.1.2](https://github.com/grocy/grocy/releases/tag/v3.1.2).

Tested locally by bringing the `grocy` application up using the `Makefile`, in combination with the changes from #144.

Based upon #143 to try to create a conflict-free series of merges (#143, then #144, then this).