### PR TITLE
Add '--frozen-lockfile' argument to 'yarn install' step

### DIFF
--- a/Dockerfile-grocy-frontend
+++ b/Dockerfile-grocy-frontend
@@ -54,7 +54,7 @@ RUN     set -o pipefail && \
         rm -rf ${GNUPGHOME}
 
 # Install application dependencies
-RUN     yarn install --modules-folder /var/www/public/node_modules --production && \
+RUN     yarn install --frozen-lockfile --modules-folder /var/www/public/node_modules --production && \
         yarn cache clean
 
 # Remove build-time dependencies (privileged)


### PR DESCRIPTION
This causes the yarn dependency installation step to fail if the application's dependencies can't be satisfied from the lockfile.

By default, without this argument, yarn may check for updated package versions and modify the dependency set (and lockfile) if the dependencies cannot initially be satisfied.

Resolves #146.