### PR TITLE
Fixup: corrections for test script targets in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": ".",
   "scripts": {
     "build": "docker-compose build",
-    "test": "npm run build && npm run test:grocy && npm run test:nginx",
+    "test": "npm run build && npm run test:backend && npm run test:frontend",
     "test:backend": "npx snyk test --docker grocy/backend:v3.1.2-0 --file=Dockerfile-grocy-backend",
     "test:frontend": "npx snyk test --docker grocy/frontend:v3.1.2-0 --file=Dockerfile-grocy-frontend"
   },


### PR DESCRIPTION
The individual script target names were updated in https://github.com/grocy/grocy-docker/commit/607c126bd339cc1cc11f410ef5ebc271a16102e2, but the top-level `test` target that invokes them both was not.