### PR TITLE
Release v3.3.0-0

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -25,7 +25,7 @@ jobs:
         platforms: linux/amd64, linux/arm64/v8
         containerfiles: Dockerfile-grocy-backend
         build-args: |
-          GROCY_VERSION=v3.2.0
+          GROCY_VERSION=v3.3.0
           COMPOSER_VERSION=2.1.5
           COMPOSER_CHECKSUM=be95557cc36eeb82da0f4340a469bad56b57f742d2891892dcb2f8b0179790ec
     - id: build-grocy-frontend
@@ -36,7 +36,7 @@ jobs:
         platforms: linux/amd64, linux/arm64/v8
         containerfiles: Dockerfile-grocy-frontend
         build-args: |
-          GROCY_VERSION=v3.2.0
+          GROCY_VERSION=v3.3.0
     # Publish the container manifests
     - uses: redhat-actions/push-to-registry@v2.5
       with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [v3.3.0-0] - 2022-04-25
+
+- Upgrade to grocy v3.3.0
+- Rebuild container images with Alpine 3.15.4
+
 ## [v3.2.0-1] - 2022-03-20
 
 - Rebuild container images with Alpine 3.15.1

--- a/Dockerfile-grocy-backend
+++ b/Dockerfile-grocy-backend
@@ -1,6 +1,6 @@
 ARG PLATFORM
 
-FROM --platform=${PLATFORM} docker.io/alpine:3.15.1
+FROM --platform=${PLATFORM} docker.io/alpine:3.15.4
 LABEL maintainer "Talmai Oliveira <to@talm.ai>, James Addison <jay@jp-hosting.net>"
 
 ARG GROCY_VERSION

--- a/Dockerfile-grocy-frontend
+++ b/Dockerfile-grocy-frontend
@@ -1,6 +1,6 @@
 ARG PLATFORM
 
-FROM --platform=${PLATFORM} docker.io/alpine:3.15.1
+FROM --platform=${PLATFORM} docker.io/alpine:3.15.4
 LABEL maintainer "Talmai Oliveira <to@talm.ai>, James Addison <jay@jp-hosting.net>"
 
 ARG GROCY_VERSION

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: build run pod manifest manifest-create %-backend %-frontend
 
-GROCY_VERSION = v3.2.0
+GROCY_VERSION = v3.3.0
 COMPOSER_VERSION = 2.1.5
 COMPOSER_CHECKSUM = be95557cc36eeb82da0f4340a469bad56b57f742d2891892dcb2f8b0179790ec
 IMAGE_TAG ?= $(shell git describe --tags --match 'v*' --dirty)

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Follow [these instructions](https://docs.docker.com/install/) to get Docker runn
 To get started using pre-built [Docker Hub grocy images](https://hub.docker.com/u/grocy), run the following commands:
 
 ```sh
-export GROCY_IMAGE_TAG=v3.2.0-1
+export GROCY_IMAGE_TAG=v3.3.0-0
 docker-compose pull
 docker-compose up
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     image: "grocy/frontend:${GROCY_IMAGE_TAG}"
     build:
       args:
-        GROCY_VERSION: v3.2.0
+        GROCY_VERSION: v3.3.0
         PLATFORM: linux/amd64
       context: .
       dockerfile: Dockerfile-grocy-frontend
@@ -25,7 +25,7 @@ services:
     image: "grocy/backend:${GROCY_IMAGE_TAG}"
     build:
       args:
-        GROCY_VERSION: v3.2.0
+        GROCY_VERSION: v3.3.0
         PLATFORM: linux/amd64
         COMPOSER_VERSION: "2.1.5"
         COMPOSER_CHECKSUM: "be95557cc36eeb82da0f4340a469bad56b57f742d2891892dcb2f8b0179790ec"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "grocy-docker",
-  "version": "3.2.0-1",
+  "version": "3.3.0-0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "3.2.0-1",
+      "version": "3.3.0-0",
       "license": "MIT",
       "devDependencies": {
         "snyk": "^1.744.0"

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "name": "grocy-docker",
-  "version": "3.2.0-1",
+  "version": "3.3.0-0",
   "description": "ERP beyond your fridge - now containerized",
   "main": ".",
   "scripts": {
     "build": "docker-compose build",
     "test": "npm run build && npm run test:backend && npm run test:frontend",
-    "test:backend": "npx snyk test --docker grocy/backend:v3.2.0-1 --file=Dockerfile-grocy-backend",
-    "test:frontend": "npx snyk test --docker grocy/frontend:v3.2.0-1 --file=Dockerfile-grocy-frontend"
+    "test:backend": "npx snyk test --docker grocy/backend:v3.3.0-0 --file=Dockerfile-grocy-backend",
+    "test:frontend": "npx snyk test --docker grocy/frontend:v3.3.0-0 --file=Dockerfile-grocy-frontend"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Hi!

The Docker images are not up to date, so I'd like to help.

Before changing anything, I compared the changes between tags v3.2.0-0 and v3.2.0-1 to be sure which files should be modified and made the required changes to use Grocy 3.3.0 and the Alpine Docker image 3.15.4.

With these changes, the images build and run without problems on my laptop.

I'm no Docker expert, so please, check these changes before accepting them.

Thank you in advance for Grocy and these Docker images!