### PR TITLE
Update Grocy version in GitHub Actions

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -25,7 +25,7 @@ jobs:
         platforms: linux/amd64, linux/arm64/v8
         containerfiles: Dockerfile-grocy-backend
         build-args: |
-          GROCY_VERSION=v3.3.0
+          GROCY_VERSION=v3.3.1
           COMPOSER_VERSION=2.1.5
           COMPOSER_CHECKSUM=be95557cc36eeb82da0f4340a469bad56b57f742d2891892dcb2f8b0179790ec
     - id: build-grocy-frontend
@@ -36,7 +36,7 @@ jobs:
         platforms: linux/amd64, linux/arm64/v8
         containerfiles: Dockerfile-grocy-frontend
         build-args: |
-          GROCY_VERSION=v3.3.0
+          GROCY_VERSION=v3.3.1
     # Publish the container manifests
     - uses: redhat-actions/push-to-registry@v2.5
       with:


### PR DESCRIPTION
Hi!

The Grocy version used in the GitHub Actions to generate and push the Docker images has not been updated.

The Docker images pulled from Docker Hub are still at v3.3.0.

Could you please merge this?

Thank you in advance!