### PR TITLE
Fixup attempt: run container vulnerability scanning after image publication

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -55,6 +55,7 @@ jobs:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
     # Perform vulnerability scanning
+    ## Note: please move this to *before* the container publish steps after confirming a way to use anchore/scan-action with locally-built OCI images
     - uses: anchore/scan-action@v3
       with:
         image: docker.io/grocy/${{ steps.build-grocy-backend.outputs.image-with-tag }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,13 +39,6 @@ jobs:
         containerfiles: Containerfile-frontend
         build-args: |
           GROCY_VERSION=${{ env.GROCY_VERSION }}
-    # Perform vulnerability scanning
-    - uses: anchore/scan-action@v3
-      with:
-        image: backend:${{ env.GROCY_IMAGE_TAG }}
-    - uses: anchore/scan-action@v3
-      with:
-        image: frontend:${{ env.GROCY_IMAGE_TAG }}
     # Publish the container manifests
     - uses: redhat-actions/push-to-registry@v2.5
       with:
@@ -61,3 +54,10 @@ jobs:
         registry: docker.io/grocy
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
+    # Perform vulnerability scanning
+    - uses: anchore/scan-action@v3
+      with:
+        image: backend:${{ env.GROCY_IMAGE_TAG }}
+    - uses: anchore/scan-action@v3
+      with:
+        image: frontend:${{ env.GROCY_IMAGE_TAG }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -57,7 +57,7 @@ jobs:
     # Perform vulnerability scanning
     - uses: anchore/scan-action@v3
       with:
-        image: backend:${{ env.GROCY_IMAGE_TAG }}
+        image: docker.io/grocy/${{ steps.build-grocy-backend.outputs.image-with-tag }}
     - uses: anchore/scan-action@v3
       with:
-        image: frontend:${{ env.GROCY_IMAGE_TAG }}
+        image: docker.io/grocy/${{ steps.build-grocy-frontend.outputs.image-with-tag }}


### PR DESCRIPTION
As the included comment notes/hints, this isn't ideal - but it's better than no scanning of the containers.

Merging after self-review momentarily, and then will move ahead to confirm whether this works by starting a release-initiated GitHub Actions pipeline.