### PR TITLE
Container publication+scanning workflow tweaks

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -62,7 +62,9 @@ jobs:
       with:
         image: docker.io/grocy/${{ steps.build-grocy-backend.outputs.image-with-tag }}
         acs-report-enable: true
+        fail-build: false  # TODO: remove this when scan-action steps are moved to before container publish
     - uses: anchore/scan-action@v3
       with:
         image: docker.io/grocy/${{ steps.build-grocy-frontend.outputs.image-with-tag }}
         acs-report-enable: true
+        fail-build: false  # TODO: remove this when scan-action steps are moved to before container publish

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   build_and_push_latest:
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write  # permit upload of sarif output from the workflow
     env:
       GROCY_IMAGE_TAG: ${{ github.event.release.tag_name }}
     steps:
@@ -59,6 +61,8 @@ jobs:
     - uses: anchore/scan-action@v3
       with:
         image: docker.io/grocy/${{ steps.build-grocy-backend.outputs.image-with-tag }}
+        acs-report-enable: true
     - uses: anchore/scan-action@v3
       with:
         image: docker.io/grocy/${{ steps.build-grocy-frontend.outputs.image-with-tag }}
+        acs-report-enable: true


### PR DESCRIPTION
- Enable publication of SARIF report from the container scanning steps
- Allow the workflow to proceed despite failure codes from the scanning steps (this should be removed in future - and will be reverted straight away if the SARIF output doesn't clearly indicate to release managers if vulnerabilities are detected)