### PR TITLE
Update to alpine:3.16.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Unreleased] - 2022-07-19
+
+- Rebuild container images with Alpine 3.16.1
+
 ## [v3.3.1-2] - 2022-06-25
 
 - Release process changes (#168)

--- a/Containerfile-backend
+++ b/Containerfile-backend
@@ -1,6 +1,6 @@
 ARG PLATFORM
 
-FROM --platform=${PLATFORM} docker.io/alpine:3.16.0
+FROM --platform=${PLATFORM} docker.io/alpine:3.16.1
 LABEL maintainer "Talmai Oliveira <to@talm.ai>, James Addison <jay@jp-hosting.net>"
 
 ARG GROCY_VERSION

--- a/Containerfile-frontend
+++ b/Containerfile-frontend
@@ -1,6 +1,6 @@
 ARG PLATFORM
 
-FROM --platform=${PLATFORM} docker.io/alpine:3.16.0
+FROM --platform=${PLATFORM} docker.io/alpine:3.16.1
 LABEL maintainer "Talmai Oliveira <to@talm.ai>, James Addison <jay@jp-hosting.net>"
 
 ARG GROCY_VERSION


### PR DESCRIPTION
Smoke-tested locally by building for `amd64` using the `Makefile`; login to the web interface was successful, and browsing through most of the pages displayed no obvious errors or regressions.