### PR TITLE
Centralize docker-compose variables

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,8 @@
+GROCY_VERSION=v3.3.1
+GROCY_REPO=https://github.com/grocy/grocy.git
+GROCY_RELEASE_KEY_URI=https://berrnd.de/data/Bernd_Bestel.asc
+
+PLATFORM=linux/amd64
+
+COMPOSER_CHECKSUM=be95557cc36eeb82da0f4340a469bad56b57f742d2891892dcb2f8b0179790ec
+COMPOSER_VERSION=2.1.5

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 .vscode
+.gitpod.yml

--- a/Containerfile-backend
+++ b/Containerfile-backend
@@ -3,9 +3,11 @@ ARG PLATFORM
 FROM --platform=${PLATFORM} docker.io/alpine:3.16.1
 LABEL maintainer "Talmai Oliveira <to@talm.ai>, James Addison <jay@jp-hosting.net>"
 
+ARG GROCY_REPO
 ARG GROCY_VERSION
 ARG COMPOSER_VERSION
 ARG COMPOSER_CHECKSUM
+ARG GROCY_RELEASE_KEY_URI
 
 # ensure www-data user exists
 RUN set -eux; \
@@ -60,11 +62,10 @@ USER www-data
 WORKDIR /var/www
 
 # Extract application release package
-ENV GROCY_RELEASE_KEY_URI="https://berrnd.de/data/Bernd_Bestel.asc"
 RUN     set -o pipefail && \
         export GNUPGHOME=$(mktemp -d) && \
         wget ${GROCY_RELEASE_KEY_URI} -O - | gpg --batch --import && \
-        git clone --branch ${GROCY_VERSION} --config advice.detachedHead=false --depth 1 "https://github.com/grocy/grocy.git" . && \
+        git clone --branch ${GROCY_VERSION} --config advice.detachedHead=false --depth 1 "${GROCY_REPO}" . && \
         git verify-commit ${GROCY_VERSION} && \
         rm -rf ${GNUPGHOME} && \
         mkdir data/viewcache && \

--- a/Containerfile-frontend
+++ b/Containerfile-frontend
@@ -3,6 +3,7 @@ ARG PLATFORM
 FROM --platform=${PLATFORM} docker.io/alpine:3.16.1
 LABEL maintainer "Talmai Oliveira <to@talm.ai>, James Addison <jay@jp-hosting.net>"
 
+ARG GROCY_REPO
 ARG GROCY_VERSION
 
 # Install build-time dependencies
@@ -45,11 +46,10 @@ USER nginx
 WORKDIR /var/www
 
 # Extract application release package
-ENV GROCY_RELEASE_KEY_URI="https://berrnd.de/data/Bernd_Bestel.asc"
 RUN     set -o pipefail && \
         export GNUPGHOME=$(mktemp -d) && \
-        wget ${GROCY_RELEASE_KEY_URI} -O - | gpg --batch --import && \
-        git clone --branch ${GROCY_VERSION} --config advice.detachedHead=false --depth 1 "https://github.com/grocy/grocy.git" . && \
+        wget "${GROCY_RELEASE_KEY_URI}" -O - | gpg --batch --import && \
+        git clone --branch ${GROCY_VERSION} --config advice.detachedHead=false --depth 1 "${GROCY_REPO}" . && \
         git verify-commit ${GROCY_VERSION} && \
         rm -rf ${GNUPGHOME}
 

--- a/Containerfile-frontend
+++ b/Containerfile-frontend
@@ -49,7 +49,7 @@ ENV GROCY_RELEASE_KEY_URI="https://berrnd.de/data/Bernd_Bestel.asc"
 RUN     set -o pipefail && \
         export GNUPGHOME=$(mktemp -d) && \
         wget ${GROCY_RELEASE_KEY_URI} -O - | gpg --batch --import && \
-        git clone --branch ${GROCY_VERSION} --config advice.detachedHead=false --depth 1 "https://github.com/grocy/grocy.git" . && \
+        git clone --branch ${GROCY_VERSION} --config advice.detachedHead=false --depth 1 "ghttps://github.com/grocy/grocy.git" . && \
         git verify-commit ${GROCY_VERSION} && \
         rm -rf ${GNUPGHOME}
 

--- a/Containerfile-frontend
+++ b/Containerfile-frontend
@@ -49,7 +49,7 @@ ENV GROCY_RELEASE_KEY_URI="https://berrnd.de/data/Bernd_Bestel.asc"
 RUN     set -o pipefail && \
         export GNUPGHOME=$(mktemp -d) && \
         wget ${GROCY_RELEASE_KEY_URI} -O - | gpg --batch --import && \
-        git clone --branch ${GROCY_VERSION} --config advice.detachedHead=false --depth 1 "ghttps://github.com/grocy/grocy.git" . && \
+        git clone --branch ${GROCY_VERSION} --config advice.detachedHead=false --depth 1 "https://github.com/grocy/grocy.git" . && \
         git verify-commit ${GROCY_VERSION} && \
         rm -rf ${GNUPGHOME}
 

--- a/README.md
+++ b/README.md
@@ -13,10 +13,9 @@ Follow [these instructions](https://docs.docker.com/install/) to get Docker runn
 
 ## Quickstart
 
-To get started using pre-built [Docker Hub grocy images](https://hub.docker.com/u/grocy), run the following commands:
+To get started using pre-built [Docker Hub grocy images](https://hub.docker.com/u/grocy), run the following command:
 
 ```sh
-docker-compose pull
 docker-compose up
 ```
 
@@ -29,11 +28,11 @@ Since the images contain self-signed certificates, your browser may display a wa
 
 ### Configuration
 
-The grocy application reads configuration settings from environment variables prefixed by `GROCY_`.
+Grocy for Docker setup environment variables are found under [.env](.env) file
 
-Runtime environment variables are read by `docker-compose` from the [grocy.env](grocy.env) file in this directory.
+Grocy runtime environment variables are read by `docker-compose` from the [grocy.env](grocy.env) file in this directory.
 
-The default login credentials are username `admin` and password `admin`; please change these before providing end-user access to your deployment.
+Grocy application reads configuration settings from environment variables prefixed by `GROCY_`.
 
 #### Demo Mode
 
@@ -42,6 +41,8 @@ To run the container in demo mode, override the `GROCY_MODE` environment variabl
 ```sh
 GROCY_MODE=demo docker-compose up
 ```
+
+The default login credentials are username `admin` and password `admin`; please change these before providing end-user access to your deployment.
 
 ### Build
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,7 @@ services:
     build:
       args:
         GROCY_VERSION: v3.3.1
+        GROCY_REPO: 
         PLATFORM: linux/amd64
         COMPOSER_VERSION: "2.1.5"
         COMPOSER_CHECKSUM: "be95557cc36eeb82da0f4340a469bad56b57f742d2891892dcb2f8b0179790ec"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,13 +1,14 @@
-version: '2.4'
+version: '2.5'
 
 services:
 
   frontend:
-    image: "grocy/frontend:v3.3.1"
+    image: "grocy/frontend:${GROCY_VERSION}"
     build:
       args:
-        GROCY_VERSION: v3.3.1
-        PLATFORM: linux/amd64
+        GROCY_VERSION: ${GROCY_VERSION}
+        GROCY_REPO: "${GROCY_REPO}"
+        PLATFORM: ${PLATFORM}
       context: .
       dockerfile: Containerfile-frontend
     depends_on:
@@ -22,14 +23,14 @@ services:
       - /var/log/nginx
 
   backend:
-    image: "grocy/backend:v3.3.1"
+    image: "grocy/backend:${GROCY_VERSION}"
     build:
       args:
-        GROCY_VERSION: v3.3.1
-        GROCY_REPO: 
-        PLATFORM: linux/amd64
-        COMPOSER_VERSION: "2.1.5"
-        COMPOSER_CHECKSUM: "be95557cc36eeb82da0f4340a469bad56b57f742d2891892dcb2f8b0179790ec"
+        GROCY_VERSION: ${GROCY_VERSION}
+        GROCY_REPO: "${GROCY_REPO}"
+        PLATFORM: ${PLATFORM}
+        COMPOSER_VERSION: "${COMPOSER_VERSION}"
+        COMPOSER_CHECKSUM: "${COMPOSER_CHECKSUM}"
       context: .
       dockerfile: Containerfile-backend
     expose:


### PR DESCRIPTION
I created a .env file to centralize the docker-compose variables. For ease of use and to make it easy for modification by the community; specifically for referencing to other modified grocy repo's