### PR TITLE
Deprecate support for self-signed TLS certificates in frontend container

### DIFF
--- a/Containerfile-frontend
+++ b/Containerfile-frontend
@@ -7,7 +7,6 @@ ARG GROCY_VERSION
 
 # Install build-time dependencies
 RUN     apk add --no-cache \
-            openssl \
             git \
             gnupg \
             wget \
@@ -18,18 +17,6 @@ RUN     apk update && \
         apk add --no-cache \
             nginx
 
-# Generate TLS certificates
-RUN     openssl req \
-                -x509 \
-                -newkey rsa:2048 \
-                -keyout /etc/ssl/private/grocy-nginx.key \
-                -out /etc/ssl/private/grocy-nginx.crt \
-                -days 365 \
-                -nodes \
-                -subj /CN=localhost && \
-        chown nginx /etc/ssl/private/grocy-nginx.key && \
-        chown nginx /etc/ssl/private/grocy-nginx.crt
-
 # Configure directory permissions
 RUN     chown -R nginx /var/log/nginx && \
         rm -rf /var/www/localhost && \
@@ -38,7 +25,6 @@ RUN     chown -R nginx /var/log/nginx && \
 COPY static/frontend/nginx.conf /etc/nginx/nginx.conf
 COPY static/frontend/common.conf /etc/nginx/common.conf
 COPY static/frontend/conf.d/default.conf /etc/nginx/conf.d/default.conf
-COPY static/frontend/conf.d/ssl.conf /etc/nginx/conf.d/ssl.conf
 
 # Install application dependencies (unprivileged)
 USER nginx
@@ -60,7 +46,6 @@ RUN     yarn install --frozen-lockfile --modules-folder /var/www/public/node_mod
 # Remove build-time dependencies (privileged)
 USER root
 RUN     apk del \
-            openssl \
             git \
             gnupg \
             wget \
@@ -68,7 +53,7 @@ RUN     apk del \
 
 VOLUME ["/var/log/nginx"]
 
-EXPOSE 8080 8443
+EXPOSE 8080
 
 USER nginx
 

--- a/Containerfile-frontend-tls-selfsigned
+++ b/Containerfile-frontend-tls-selfsigned
@@ -1,0 +1,75 @@
+ARG PLATFORM
+
+FROM --platform=${PLATFORM} docker.io/alpine:3.16.2
+LABEL maintainer "Talmai Oliveira <to@talm.ai>, James Addison <jay@jp-hosting.net>"
+
+ARG GROCY_VERSION
+
+# Install build-time dependencies
+RUN     apk add --no-cache \
+            openssl \
+            git \
+            gnupg \
+            wget \
+            yarn
+
+# Install system dependencies
+RUN     apk update && \
+        apk add --no-cache \
+            nginx
+
+# Generate TLS certificates
+RUN     openssl req \
+                -x509 \
+                -newkey rsa:2048 \
+                -keyout /etc/ssl/private/grocy-nginx.key \
+                -out /etc/ssl/private/grocy-nginx.crt \
+                -days 365 \
+                -nodes \
+                -subj /CN=localhost && \
+        chown nginx /etc/ssl/private/grocy-nginx.key && \
+        chown nginx /etc/ssl/private/grocy-nginx.crt
+
+# Configure directory permissions
+RUN     chown -R nginx /var/log/nginx && \
+        rm -rf /var/www/localhost && \
+        chown nginx /var/www
+
+COPY static/frontend/nginx.conf /etc/nginx/nginx.conf
+COPY static/frontend/common.conf /etc/nginx/common.conf
+COPY static/frontend/conf.d/default.conf /etc/nginx/conf.d/default.conf
+COPY static/frontend/conf.d/ssl.conf /etc/nginx/conf.d/ssl.conf
+
+# Install application dependencies (unprivileged)
+USER nginx
+WORKDIR /var/www
+
+# Extract application release package
+ENV GROCY_RELEASE_KEY_URI="https://berrnd.de/data/Bernd_Bestel.asc"
+RUN     set -o pipefail && \
+        export GNUPGHOME=$(mktemp -d) && \
+        wget ${GROCY_RELEASE_KEY_URI} -O - | gpg --batch --import && \
+        git clone --branch ${GROCY_VERSION} --config advice.detachedHead=false --depth 1 "https://github.com/grocy/grocy.git" . && \
+        git verify-commit ${GROCY_VERSION} && \
+        rm -rf ${GNUPGHOME}
+
+# Install application dependencies
+RUN     yarn install --frozen-lockfile --modules-folder /var/www/public/node_modules --production && \
+        yarn cache clean
+
+# Remove build-time dependencies (privileged)
+USER root
+RUN     apk del \
+            openssl \
+            git \
+            gnupg \
+            wget \
+            yarn
+
+VOLUME ["/var/log/nginx"]
+
+EXPOSE 8080 8443
+
+USER nginx
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/README.md
+++ b/README.md
@@ -25,9 +25,6 @@ This will retrieve and start the most recent container images corresponding to t
 The grocy application should now be accessible locally to the server:
 
  - [http://localhost](http://localhost)
- - [https://localhost](https://localhost)
-
-Since the images contain self-signed certificates, your browser may display a warning when visiting the HTTPS URL.
 
 ### Configuration
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,6 @@ services:
       - backend
     ports:
       - '127.0.0.1:80:8080'
-      - '127.0.0.1:443:8443'
     read_only: true
     tmpfs:
       - /tmp


### PR DESCRIPTION
- Retain support for self-signed certificates in a `Containerfile-frontend-tls-selfsigned` build file
- Remove self-signed certificates from the `Containerfile-frontend` build file