### PR TITLE
Remove VOLUME step in Nginx frontend to fix #189

### DIFF
--- a/Containerfile-frontend
+++ b/Containerfile-frontend
@@ -51,8 +51,6 @@ RUN     apk del \
             wget \
             yarn
 
-VOLUME ["/var/log/nginx"]
-
 EXPOSE 8080
 
 USER nginx

--- a/Containerfile-frontend-tls-selfsigned
+++ b/Containerfile-frontend-tls-selfsigned
@@ -66,8 +66,6 @@ RUN     apk del \
             wget \
             yarn
 
-VOLUME ["/var/log/nginx"]
-
 EXPOSE 8080 8443
 
 USER nginx


### PR DESCRIPTION
This way no anonymous volumes are created if the folder isn't mounted. 
There is no way currently to block a volume from being created if it is specified in the image.