### PR TITLE
Retain a copy of the nginx configuration for the frontend container(s)

### DIFF
--- a/Containerfile-frontend-tls-selfsigned
+++ b/Containerfile-frontend-tls-selfsigned
@@ -35,10 +35,10 @@ RUN     chown -R nginx /var/log/nginx && \
         rm -rf /var/www/localhost && \
         chown nginx /var/www
 
-COPY static/frontend/nginx.conf /etc/nginx/nginx.conf
-COPY static/frontend/common.conf /etc/nginx/common.conf
-COPY static/frontend/conf.d/default.conf /etc/nginx/conf.d/default.conf
-COPY static/frontend/conf.d/ssl.conf /etc/nginx/conf.d/ssl.conf
+COPY static/frontend-tls-selfsigned/nginx.conf /etc/nginx/nginx.conf
+COPY static/frontend-tls-selfsigned/common.conf /etc/nginx/common.conf
+COPY static/frontend-tls-selfsigned/conf.d/default.conf /etc/nginx/conf.d/default.conf
+COPY static/frontend-tls-selfsigned/conf.d/ssl.conf /etc/nginx/conf.d/ssl.conf
 
 # Install application dependencies (unprivileged)
 USER nginx

--- a/static/frontend-tls-selfsigned/common.conf
+++ b/static/frontend-tls-selfsigned/common.conf
@@ -1,0 +1,20 @@
+charset utf-8;
+
+location / {
+    try_files $uri /index.php$is_args$query_string;
+}
+
+location ~* .(jpg|jpeg|png|gif|ico|css|js)$ {
+    expires 365d;
+}
+
+location ~ \.php$ {
+    fastcgi_pass   backend:9000;
+    fastcgi_index  index.php;
+    fastcgi_param  SCRIPT_FILENAME  $document_root$fastcgi_script_name;
+    include        fastcgi_params;
+}
+
+location ~ /\.ht {
+    deny  all;
+}

--- a/static/frontend-tls-selfsigned/conf.d/default.conf
+++ b/static/frontend-tls-selfsigned/conf.d/default.conf
@@ -1,0 +1,8 @@
+server {
+    listen 8080 default_server;
+    server_name _;
+    
+    root /var/www/public; # see: volumes_from
+    
+    include /etc/nginx/common.conf;
+}

--- a/static/frontend-tls-selfsigned/conf.d/ssl.conf
+++ b/static/frontend-tls-selfsigned/conf.d/ssl.conf
@@ -1,0 +1,11 @@
+server {
+    listen 8443 ssl;
+    server_name _;
+    
+    root /var/www/public; # see: volumes_from
+
+    ssl_certificate      /etc/ssl/private/grocy-nginx.crt;
+    ssl_certificate_key  /etc/ssl/private/grocy-nginx.key;
+    
+    include /etc/nginx/common.conf;
+}

--- a/static/frontend-tls-selfsigned/nginx.conf
+++ b/static/frontend-tls-selfsigned/nginx.conf
@@ -1,0 +1,33 @@
+worker_processes auto;
+
+pid /tmp/nginx.pid;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    # Basic mime type configuration
+    include mime.types;
+    default_type application/octet-stream;
+
+    # Configuration related to client connections and content upload
+    sendfile on;
+    tcp_nopush on;
+    tcp_nodelay on;
+    client_max_body_size 50M;
+
+    # Write nginx temporary files to /tmp in order to run in rootless configuration
+    # See: https://hub.docker.com/_/nginx/
+    client_body_temp_path /tmp/client_temp;
+    proxy_temp_path       /tmp/proxy_temp_path;
+    fastcgi_temp_path     /tmp/fastcgi_temp;
+    uwsgi_temp_path       /tmp/uwsgi_temp;
+    scgi_temp_path        /tmp/scgi_temp;
+
+    # Enable compression for application content
+    gzip on;
+    gzip_types application/javascript application/json application/octet-stream application/pdf font/woff font/woff2 image/gif image/jpeg image/png image/webp image/x-icon text/css;
+
+    include /etc/nginx/conf.d/*.conf;
+}


### PR DESCRIPTION
This allows for the configuration file contents to diverge between `frontend` and `frontend-tls-selfsigned` variants.

It's more duplication short-term, and should really have been handled during #184 - I didn't remember to do this at the time.