### PR TITLE
Update container logging configuration: use stdout for access logs, stderr for error logs

### DIFF
--- a/static/backend/www.conf
+++ b/static/backend/www.conf
@@ -3,7 +3,7 @@ daemonize = no
 error_log = /proc/self/fd/2
 
 [www]
-access.log = /proc/self/fd/2
+access.log = /proc/self/fd/2 ; workaround: https://bugs.php.net/bug.php?id=73886
 catch_workers_output = yes
 clear_env = no
 listen = 9000

--- a/static/backend/www.conf
+++ b/static/backend/www.conf
@@ -1,9 +1,9 @@
 [global]
 daemonize = no
-error_log = /dev/stderr
+error_log = /proc/self/fd/2
 
 [www]
-access.log = /dev/stdout
+access.log = /proc/self/fd/2
 catch_workers_output = yes
 clear_env = no
 listen = 9000

--- a/static/backend/www.conf
+++ b/static/backend/www.conf
@@ -1,6 +1,8 @@
 [global]
 daemonize = no
+error_log = /dev/stderr
 
 [www]
+access.log = /dev/stdout
 clear_env = no
 listen = 9000

--- a/static/backend/www.conf
+++ b/static/backend/www.conf
@@ -4,5 +4,6 @@ error_log = /dev/stderr
 
 [www]
 access.log = /dev/stdout
+catch_workers_output = yes
 clear_env = no
 listen = 9000

--- a/static/frontend-tls-selfsigned/conf.d/default.conf
+++ b/static/frontend-tls-selfsigned/conf.d/default.conf
@@ -3,6 +3,7 @@ server {
     server_name _;
     
     root /var/www/public; # see: volumes_from
+    access_log /dev/stdout;
     
     include /etc/nginx/common.conf;
 }

--- a/static/frontend-tls-selfsigned/conf.d/default.conf
+++ b/static/frontend-tls-selfsigned/conf.d/default.conf
@@ -3,7 +3,7 @@ server {
     server_name _;
     
     root /var/www/public; # see: volumes_from
-    access_log /dev/stdout;
+    access_log /proc/self/fd/1;
     
     include /etc/nginx/common.conf;
 }

--- a/static/frontend-tls-selfsigned/conf.d/ssl.conf
+++ b/static/frontend-tls-selfsigned/conf.d/ssl.conf
@@ -3,7 +3,7 @@ server {
     server_name _;
     
     root /var/www/public; # see: volumes_from
-    access_log /dev/stdout;
+    access_log /proc/self/fd/1;
 
     ssl_certificate      /etc/ssl/private/grocy-nginx.crt;
     ssl_certificate_key  /etc/ssl/private/grocy-nginx.key;

--- a/static/frontend-tls-selfsigned/conf.d/ssl.conf
+++ b/static/frontend-tls-selfsigned/conf.d/ssl.conf
@@ -3,6 +3,7 @@ server {
     server_name _;
     
     root /var/www/public; # see: volumes_from
+    access_log /dev/stdout;
 
     ssl_certificate      /etc/ssl/private/grocy-nginx.crt;
     ssl_certificate_key  /etc/ssl/private/grocy-nginx.key;

--- a/static/frontend/conf.d/default.conf
+++ b/static/frontend/conf.d/default.conf
@@ -3,6 +3,7 @@ server {
     server_name _;
     
     root /var/www/public; # see: volumes_from
+    access_log /dev/stdout;
     
     include /etc/nginx/common.conf;
 }

--- a/static/frontend/conf.d/default.conf
+++ b/static/frontend/conf.d/default.conf
@@ -3,7 +3,7 @@ server {
     server_name _;
     
     root /var/www/public; # see: volumes_from
-    access_log /dev/stdout;
+    access_log /proc/self/fd/1;
     
     include /etc/nginx/common.conf;
 }

--- a/static/frontend/nginx.conf
+++ b/static/frontend/nginx.conf
@@ -1,6 +1,7 @@
 worker_processes auto;
 
 pid /tmp/nginx.pid;
+error_log /dev/stderr;
 
 events {
     worker_connections 1024;

--- a/static/frontend/nginx.conf
+++ b/static/frontend/nginx.conf
@@ -1,7 +1,7 @@
 worker_processes auto;
 
 pid /tmp/nginx.pid;
-error_log /dev/stderr;
+error_log /proc/self/fd/2;
 
 events {
     worker_connections 1024;


### PR DESCRIPTION
Resolves #191.