### PR TITLE
Cleanup: remove references to legacy filesystem logging from build steps and container volume definitions

### DIFF
--- a/Containerfile-backend
+++ b/Containerfile-backend
@@ -42,8 +42,7 @@ RUN     apk add --no-cache \
             php8-intl
 
 # Configure directory permissions
-RUN     chown www-data /var/log/php8 && \
-        mkdir /var/www && \
+RUN     mkdir /var/www && \
         chown www-data /var/www
 
 COPY static/backend/www.conf /etc/php8/php-fpm.d/zz-docker.conf

--- a/Containerfile-frontend
+++ b/Containerfile-frontend
@@ -18,8 +18,7 @@ RUN     apk update && \
             nginx
 
 # Configure directory permissions
-RUN     chown -R nginx /var/log/nginx && \
-        rm -rf /var/www/localhost && \
+RUN     rm -rf /var/www/localhost && \
         chown nginx /var/www
 
 COPY static/frontend/nginx.conf /etc/nginx/nginx.conf

--- a/Containerfile-frontend-tls-selfsigned
+++ b/Containerfile-frontend-tls-selfsigned
@@ -31,8 +31,7 @@ RUN     openssl req \
         chown nginx /etc/ssl/private/grocy-nginx.crt
 
 # Configure directory permissions
-RUN     chown -R nginx /var/log/nginx && \
-        rm -rf /var/www/localhost && \
+RUN     rm -rf /var/www/localhost && \
         chown nginx /var/www
 
 COPY static/frontend-tls-selfsigned/nginx.conf /etc/nginx/nginx.conf

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,6 @@ create: pod
         --name backend \
         --pod grocy-pod \
         --read-only \
-        --volume /var/log/php8 \
         --volume app-db:/var/www/data \
         ${IMAGE_PREFIX}/backend:${IMAGE_TAG}
 	podman create \
@@ -22,7 +21,6 @@ create: pod
         --pod grocy-pod \
         --read-only \
         --tmpfs /tmp \
-        --volume /var/log/nginx \
         ${IMAGE_PREFIX}/frontend:${IMAGE_TAG}
 
 run: create

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,8 +17,6 @@ services:
     read_only: true
     tmpfs:
       - /tmp
-    volumes:
-      - /var/log/nginx
     restart: unless-stopped
 
   backend:
@@ -35,7 +33,6 @@ services:
     tmpfs:
       - /tmp
     volumes:
-      - /var/log/php8
       - app-db:/var/www/data
     env_file:
       - grocy.env


### PR DESCRIPTION
Since the merge of #195, containers log to `stderr` and `stdout` instead of the container's filesystem.