### PR TITLE
Fix startup error introduced in #203

### DIFF
--- a/Containerfile-frontend
+++ b/Containerfile-frontend
@@ -54,4 +54,4 @@ EXPOSE 8080
 
 USER nginx
 
-CMD ["nginx", "-g", "daemon off;"]
+CMD ["nginx", "-g", "daemon off;", "-e", "/proc/self/fd/2"]

--- a/Containerfile-frontend-tls-selfsigned
+++ b/Containerfile-frontend-tls-selfsigned
@@ -69,4 +69,4 @@ EXPOSE 8080 8443
 
 USER nginx
 
-CMD ["nginx", "-g", "daemon off;"]
+CMD ["nginx", "-g", "daemon off;", "-e", "/proc/self/fd/2"]


### PR DESCRIPTION
This error is caused because of https://trac.nginx.org/nginx/ticket/147 .
Nginx attempts to log to the filesystem during startup
even if after startup, all output is redirected.
This means we can also close #191 again.

Output of frontend before this fix:
```
nginx: [alert] could not open error log file: open() "/var/lib/nginx/logs/error.log" failed (30: Read-only file system)
```
Afterwards:
No output

--- maintainer edit: adding ticket auto-close reference
Closes #191.