### PR TITLE
Re-apply "Update to alpine:3.17.0"

### DIFF
--- a/Containerfile-backend
+++ b/Containerfile-backend
@@ -1,6 +1,6 @@
 ARG PLATFORM
 
-FROM --platform=${PLATFORM} docker.io/alpine:3.16.3
+FROM --platform=${PLATFORM} docker.io/alpine:3.17.0
 LABEL maintainer "Talmai Oliveira <to@talm.ai>, James Addison <jay@jp-hosting.net>"
 
 ARG GROCY_VERSION
@@ -23,29 +23,29 @@ RUN     apk update && \
 
 # Install system dependencies
 RUN     apk add --no-cache \
-            php8 \
-            php8-ctype \
-            php8-fpm \
-            php8-exif \
-            php8-fileinfo \
-            php8-gd \
-            php8-iconv \
-            php8-ldap \
-            php8-pdo_sqlite \
-            php8-simplexml \
-            php8-tokenizer \
-            php8-phar \
-            php8-curl \
-            php8-mbstring \
-            php8-openssl \
-            php8-zip \
-            php8-intl
+            php81 \
+            php81-ctype \
+            php81-fpm \
+            php81-exif \
+            php81-fileinfo \
+            php81-gd \
+            php81-iconv \
+            php81-ldap \
+            php81-pdo_sqlite \
+            php81-simplexml \
+            php81-tokenizer \
+            php81-phar \
+            php81-curl \
+            php81-mbstring \
+            php81-openssl \
+            php81-zip \
+            php81-intl
 
 # Configure directory permissions
 RUN     mkdir /var/www && \
         chown www-data /var/www
 
-COPY static/backend/www.conf /etc/php8/php-fpm.d/zz-docker.conf
+COPY static/backend/www.conf /etc/php81/php-fpm.d/zz-docker.conf
 
 # Install application dependencies (unprivileged)
 USER www-data
@@ -80,4 +80,4 @@ EXPOSE 9000
 
 USER www-data
 
-CMD ["php-fpm8"]
+CMD ["php-fpm81"]

--- a/Containerfile-frontend
+++ b/Containerfile-frontend
@@ -1,6 +1,6 @@
 ARG PLATFORM
 
-FROM --platform=${PLATFORM} docker.io/alpine:3.16.3
+FROM --platform=${PLATFORM} docker.io/alpine:3.17.0
 LABEL maintainer "Talmai Oliveira <to@talm.ai>, James Addison <jay@jp-hosting.net>"
 
 ARG GROCY_VERSION

--- a/Containerfile-frontend-tls-selfsigned
+++ b/Containerfile-frontend-tls-selfsigned
@@ -1,6 +1,6 @@
 ARG PLATFORM
 
-FROM --platform=${PLATFORM} docker.io/alpine:3.16.3
+FROM --platform=${PLATFORM} docker.io/alpine:3.17.0
 LABEL maintainer "Talmai Oliveira <to@talm.ai>, James Addison <jay@jp-hosting.net>"
 
 ARG GROCY_VERSION


### PR DESCRIPTION
Re-applies #197, given that the Grocy application now [supports PHP 8.1](https://github.com/grocy/grocy/commit/38a4ad8ec480c29a1bff057b3482fd103b036848).