### PR TITLE
Update to alpine:3.17.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Unreleased]
+
+- Rebuild container imagers with Alpine 3.17.3
+
 ## [v3.3.2-5] - 2023-02-17
 
 - Rebuild container imagers with Alpine 3.17.2

--- a/Containerfile-backend
+++ b/Containerfile-backend
@@ -1,6 +1,6 @@
 ARG PLATFORM
 
-FROM --platform=${PLATFORM} docker.io/alpine:3.17.2
+FROM --platform=${PLATFORM} docker.io/alpine:3.17.3
 LABEL maintainer "Talmai Oliveira <to@talm.ai>, James Addison <jay@jp-hosting.net>"
 
 ARG GROCY_VERSION

--- a/Containerfile-frontend
+++ b/Containerfile-frontend
@@ -1,6 +1,6 @@
 ARG PLATFORM
 
-FROM --platform=${PLATFORM} docker.io/alpine:3.17.2
+FROM --platform=${PLATFORM} docker.io/alpine:3.17.3
 LABEL maintainer "Talmai Oliveira <to@talm.ai>, James Addison <jay@jp-hosting.net>"
 
 ARG GROCY_VERSION

--- a/Containerfile-frontend-tls-selfsigned
+++ b/Containerfile-frontend-tls-selfsigned
@@ -1,6 +1,6 @@
 ARG PLATFORM
 
-FROM --platform=${PLATFORM} docker.io/alpine:3.17.2
+FROM --platform=${PLATFORM} docker.io/alpine:3.17.3
 LABEL maintainer "Talmai Oliveira <to@talm.ai>, James Addison <jay@jp-hosting.net>"
 
 ARG GROCY_VERSION


### PR DESCRIPTION
Tested locally using a [`Makefile`](https://github.com/grocy/grocy-docker/blob/fa598a3703b0c235a82ac95cfdb27d08f83b81c5/Makefile)-based build.

Separately, but somewhat related: there was an error that occurred during the first attempt to build the `frontend` container directly using `buildah bud --build-arg GROCY_VERSION=v3.3.2 Containerfile-frontend`.  That's been reported as issue #210.