### PR TITLE
Update to alpine:3.18.2

### DIFF
--- a/Containerfile-backend
+++ b/Containerfile-backend
@@ -1,6 +1,6 @@
 ARG PLATFORM
 
-FROM --platform=${PLATFORM} docker.io/alpine:3.18.0
+FROM --platform=${PLATFORM} docker.io/alpine:3.18.2
 LABEL maintainer "Talmai Oliveira <to@talm.ai>, James Addison <jay@jp-hosting.net>"
 
 ARG GROCY_VERSION

--- a/Containerfile-frontend
+++ b/Containerfile-frontend
@@ -1,6 +1,6 @@
 ARG PLATFORM
 
-FROM --platform=${PLATFORM} docker.io/alpine:3.18.0
+FROM --platform=${PLATFORM} docker.io/alpine:3.18.2
 LABEL maintainer "Talmai Oliveira <to@talm.ai>, James Addison <jay@jp-hosting.net>"
 
 ARG GROCY_VERSION


### PR DESCRIPTION
Tested locally using a [`Makefile`](https://github.com/grocy/grocy-docker/blob/a94793ff79906978fd08a0f1c3fb0ed5f08b6859/Makefile)-based build.