### PR TITLE
Update to grocy v4.0.0

### DIFF
--- a/Containerfile-frontend
+++ b/Containerfile-frontend
@@ -39,7 +39,7 @@ RUN     set -o pipefail && \
         rm -rf ${GNUPGHOME}
 
 # Install application dependencies
-RUN     yarn install --frozen-lockfile --modules-folder /var/www/public/node_modules --production && \
+RUN     yarn install --frozen-lockfile --modules-folder /var/www/public/packages --production && \
         yarn cache clean
 
 # Remove build-time dependencies (privileged)

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: build run pod manifest manifest-create %-backend %-frontend
 
-GROCY_VERSION = v3.3.2
+GROCY_VERSION = v4.0.0
 IMAGE_TAG ?= $(shell git describe --tags --match 'v*' --dirty)
 
 IMAGE_PREFIX ?= docker.io/grocy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,10 +3,10 @@ version: '2.4'
 services:
 
   frontend:
-    image: "grocy/frontend:v3.3.2"
+    image: "grocy/frontend:v4.0.0"
     build:
       args:
-        GROCY_VERSION: v3.3.2
+        GROCY_VERSION: v4.0.0
         PLATFORM: linux/amd64
       context: .
       dockerfile: Containerfile-frontend
@@ -20,10 +20,10 @@ services:
     restart: unless-stopped
 
   backend:
-    image: "grocy/backend:v3.3.2"
+    image: "grocy/backend:v4.0.0"
     build:
       args:
-        GROCY_VERSION: v3.3.2
+        GROCY_VERSION: v4.0.0
         PLATFORM: linux/amd64
       context: .
       dockerfile: Containerfile-backend


### PR DESCRIPTION
Tested locally using a [`Makefile`](https://github.com/grocy/grocy-docker/blob/b3daf34db008864626b5255bf157dc99005d0471/Makefile)-based build.