### PR TITLE
docker-compose.yml: add tmpfs mount for backend container viewcache directory

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
     read_only: true
     tmpfs:
       - /tmp
-      - /var/www/data/viewcache:mode=755,uid=82,gid=82,size=4m
+      - /var/www/data/viewcache:mode=755,uid=82,gid=82,size=16m
     volumes:
       - app-db:/var/www/data
     env_file:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,7 @@ services:
     read_only: true
     tmpfs:
       - /tmp
+      - /var/www/data/viewcache:mode=755,uid=82,gid=82,size=4m
     volumes:
       - app-db:/var/www/data
     env_file:


### PR DESCRIPTION
May resolve #217.

Todo: figure out why a similar approach doesn't work using `podman` from the `Makefile` (`uid`, `gid` seem unsupported, unexpectedly).