### PR TITLE
Update to grocy v4.0.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: build run pod manifest manifest-create %-backend %-frontend
 
-GROCY_VERSION = v4.0.1
+GROCY_VERSION = v4.0.2
 IMAGE_TAG ?= $(shell git describe --tags --match 'v*' --dirty)
 
 IMAGE_PREFIX ?= docker.io/grocy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,10 +3,10 @@ version: '2.4'
 services:
 
   frontend:
-    image: "grocy/frontend:v4.0.1"
+    image: "grocy/frontend:v4.0.2"
     build:
       args:
-        GROCY_VERSION: v4.0.1
+        GROCY_VERSION: v4.0.2
         PLATFORM: linux/amd64
       context: .
       dockerfile: Containerfile-frontend
@@ -20,10 +20,10 @@ services:
     restart: unless-stopped
 
   backend:
-    image: "grocy/backend:v4.0.1"
+    image: "grocy/backend:v4.0.2"
     build:
       args:
-        GROCY_VERSION: v4.0.1
+        GROCY_VERSION: v4.0.2
         PLATFORM: linux/amd64
       context: .
       dockerfile: Containerfile-backend


### PR DESCRIPTION
Basic functional testing performed locally using the [`Makefile`](https://github.com/grocy/grocy-docker/blob/8e389bb2738e1627deea7df92d4812cfee41ce3e/Makefile).