### PR TITLE
Update to alpine:3.18.3

### DIFF
--- a/Containerfile-backend
+++ b/Containerfile-backend
@@ -1,6 +1,6 @@
 ARG PLATFORM
 
-FROM --platform=${PLATFORM} docker.io/alpine:3.18.2
+FROM --platform=${PLATFORM} docker.io/alpine:3.18.3
 LABEL maintainer "Talmai Oliveira <to@talm.ai>, James Addison <jay@jp-hosting.net>"
 
 ARG GROCY_VERSION

--- a/Containerfile-frontend
+++ b/Containerfile-frontend
@@ -1,6 +1,6 @@
 ARG PLATFORM
 
-FROM --platform=${PLATFORM} docker.io/alpine:3.18.2
+FROM --platform=${PLATFORM} docker.io/alpine:3.18.3
 LABEL maintainer "Talmai Oliveira <to@talm.ai>, James Addison <jay@jp-hosting.net>"
 
 ARG GROCY_VERSION


### PR DESCRIPTION
Tested locally using an OCI-based container build using the [`Makefile`](https://github.com/grocy/grocy-docker/blob/0a921f13c57069400c609f3f1b8d015f4f069bca/Makefile).