### PR TITLE
Update to grocy v4.0.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: build run pod manifest manifest-create %-backend %-frontend
 
-GROCY_VERSION = v4.0.2
+GROCY_VERSION = v4.0.3
 IMAGE_TAG ?= $(shell git describe --tags --match 'v*' --dirty)
 
 IMAGE_PREFIX ?= docker.io/grocy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,10 +3,10 @@ version: '2.4'
 services:
 
   frontend:
-    image: "grocy/frontend:v4.0.2"
+    image: "grocy/frontend:v4.0.3"
     build:
       args:
-        GROCY_VERSION: v4.0.2
+        GROCY_VERSION: v4.0.3
         PLATFORM: linux/amd64
       context: .
       dockerfile: Containerfile-frontend
@@ -20,10 +20,10 @@ services:
     restart: unless-stopped
 
   backend:
-    image: "grocy/backend:v4.0.2"
+    image: "grocy/backend:v4.0.3"
     build:
       args:
-        GROCY_VERSION: v4.0.2
+        GROCY_VERSION: v4.0.3
         PLATFORM: linux/amd64
       context: .
       dockerfile: Containerfile-backend


### PR DESCRIPTION
Tested locally using a [`Makefile`](https://github.com/grocy/grocy-docker/blob/6bf65392381f3dd882cd8d8328512f33910a0302/Makefile)-based build.