### PR TITLE
Add pre-defined / well-known OCI (opencontainers) annotations

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,6 +33,7 @@ jobs:
         labels: |
           org.opencontainers.image.documentation=https://grocy.info/
           org.opencontainers.image.source=https://github.com/grocy/grocy-docker/
+          org.opencontainers.image.version=${{ github.event.release.tag_name }}
           org.opencontainers.image.licenses=MIT
     - id: build-grocy-frontend
       uses: redhat-actions/buildah-build@v2.12
@@ -46,6 +47,7 @@ jobs:
         labels: |
           org.opencontainers.image.documentation=https://grocy.info/
           org.opencontainers.image.source=https://github.com/grocy/grocy-docker/
+          org.opencontainers.image.version=${{ github.event.release.tag_name }}
           org.opencontainers.image.licenses=MIT
     # Publish the container manifests
     - uses: redhat-actions/push-to-registry@v2.5

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,6 +30,10 @@ jobs:
         containerfiles: Containerfile-backend
         build-args: |
           GROCY_VERSION=${{ env.GROCY_VERSION }}
+        labels: |
+          org.opencontainers.image.info=https://grocy.info/
+          org.opencontainers.image.source=https://github.com/grocy/grocy-docker/
+          org.opencontainers.image.licenses=MIT
     - id: build-grocy-frontend
       uses: redhat-actions/buildah-build@v2.12
       with:
@@ -39,6 +43,10 @@ jobs:
         containerfiles: Containerfile-frontend
         build-args: |
           GROCY_VERSION=${{ env.GROCY_VERSION }}
+        labels: |
+          org.opencontainers.image.info=https://grocy.info/
+          org.opencontainers.image.source=https://github.com/grocy/grocy-docker/
+          org.opencontainers.image.licenses=MIT
     # Publish the container manifests
     - uses: redhat-actions/push-to-registry@v2.5
       with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,7 +33,7 @@ jobs:
         labels: |
           org.opencontainers.image.documentation=https://grocy.info/
           org.opencontainers.image.source=https://github.com/grocy/grocy-docker/
-          org.opencontainers.image.version=${{ github.event.release.tag_name }}
+          org.opencontainers.image.version=${{ env.GROCY_IMAGE_TAG }}
           org.opencontainers.image.licenses=MIT
     - id: build-grocy-frontend
       uses: redhat-actions/buildah-build@v2.12
@@ -47,7 +47,7 @@ jobs:
         labels: |
           org.opencontainers.image.documentation=https://grocy.info/
           org.opencontainers.image.source=https://github.com/grocy/grocy-docker/
-          org.opencontainers.image.version=${{ github.event.release.tag_name }}
+          org.opencontainers.image.version=${{ env.GROCY_IMAGE_TAG }}
           org.opencontainers.image.licenses=MIT
     # Publish the container manifests
     - uses: redhat-actions/push-to-registry@v2.5

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,7 +31,7 @@ jobs:
         build-args: |
           GROCY_VERSION=${{ env.GROCY_VERSION }}
         labels: |
-          org.opencontainers.image.info=https://grocy.info/
+          org.opencontainers.image.documentation=https://grocy.info/
           org.opencontainers.image.source=https://github.com/grocy/grocy-docker/
           org.opencontainers.image.licenses=MIT
     - id: build-grocy-frontend
@@ -44,7 +44,7 @@ jobs:
         build-args: |
           GROCY_VERSION=${{ env.GROCY_VERSION }}
         labels: |
-          org.opencontainers.image.info=https://grocy.info/
+          org.opencontainers.image.documentation=https://grocy.info/
           org.opencontainers.image.source=https://github.com/grocy/grocy-docker/
           org.opencontainers.image.licenses=MIT
     # Publish the container manifests


### PR DESCRIPTION
Refs:
 - https://snyk.io/blog/how-and-when-to-use-docker-labels-oci-container-annotations/
 - https://github.com/opencontainers/image-spec/blob/67d2d5658fe0476ab9bf414cec164077ebff3920/annotations.md
 - https://man.archlinux.org/man/extra/buildah/buildah-config.1.en