### PR TITLE
Update to alpine:3.19.0 and php:8.2

### DIFF
--- a/Containerfile-backend
+++ b/Containerfile-backend
@@ -23,29 +23,29 @@ RUN     apk update && \
 
 # Install system dependencies
 RUN     apk add --no-cache \
-            php81 \
-            php81-ctype \
-            php81-fpm \
-            php81-exif \
-            php81-fileinfo \
-            php81-gd \
-            php81-iconv \
-            php81-ldap \
-            php81-pdo_sqlite \
-            php81-simplexml \
-            php81-tokenizer \
-            php81-phar \
-            php81-curl \
-            php81-mbstring \
-            php81-openssl \
-            php81-zip \
-            php81-intl
+            php82 \
+            php82-ctype \
+            php82-fpm \
+            php82-exif \
+            php82-fileinfo \
+            php82-gd \
+            php82-iconv \
+            php82-ldap \
+            php82-pdo_sqlite \
+            php82-simplexml \
+            php82-tokenizer \
+            php82-phar \
+            php82-curl \
+            php82-mbstring \
+            php82-openssl \
+            php82-zip \
+            php82-intl
 
 # Configure directory permissions
 RUN     mkdir /var/www && \
         chown www-data /var/www
 
-COPY static/backend/www.conf /etc/php81/php-fpm.d/zz-docker.conf
+COPY static/backend/www.conf /etc/php82/php-fpm.d/zz-docker.conf
 
 # Install application dependencies (unprivileged)
 USER www-data
@@ -80,4 +80,4 @@ EXPOSE 9000
 
 USER www-data
 
-CMD ["php-fpm81"]
+CMD ["php-fpm82"]

--- a/Containerfile-backend
+++ b/Containerfile-backend
@@ -1,6 +1,6 @@
 ARG PLATFORM
 
-FROM --platform=${PLATFORM} docker.io/alpine:3.18.4
+FROM --platform=${PLATFORM} docker.io/alpine:3.19.0
 LABEL maintainer "Talmai Oliveira <to@talm.ai>, James Addison <jay@jp-hosting.net>"
 
 ARG GROCY_VERSION

--- a/Containerfile-frontend
+++ b/Containerfile-frontend
@@ -1,6 +1,6 @@
 ARG PLATFORM
 
-FROM --platform=${PLATFORM} docker.io/alpine:3.18.4
+FROM --platform=${PLATFORM} docker.io/alpine:3.19.0
 LABEL maintainer "Talmai Oliveira <to@talm.ai>, James Addison <jay@jp-hosting.net>"
 
 ARG GROCY_VERSION


### PR DESCRIPTION
PHP 8.2 is currently the [latest-supported version of PHP](https://github.com/grocy/grocy/blob/b2295ce6d2fccd7d282ca77d0a4c084cbf2b74a9/README.md#platform-support) for use with Grocy v4.0.3 -- and PHP 8.1 is the minimum supported by the [recently-released Alpine 3.19.0](https://www.alpinelinux.org/posts/Alpine-3.19.0-released.html) -- so let's upgrade to PHP 8.2 while upgrading Alpine.

Note 1: I wasn't able to get the combination of PHP8.2 + Alpine 3.18.4 to work; however PHP8.2 + Alpine 3.19.0 did build and run correctly.

Note 2: I've tested the results by building and running the app using the [`Makefile`](https://github.com/grocy/grocy-docker/blob/0e11648664dfd6314a94ffd10bbfde16304b3291/Makefile) - login to Grocy and basic functionality all appears working fine.