### PR TITLE
Enable dependabot for Docker image

### DIFF
--- a/.github/.github/dependabot.yml
+++ b/.github/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  # Maintain dependencies for GitHub Actions
+  # src: https://github.com/marketplace/actions/build-and-push-docker-images#keep-up-to-date-with-github-dependabot
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
AFAIK (and this was new to me) Dependabot is not active by default.

This enables it for all dependencies here, so it scans and suggests updates. See https://docs.github.com/en/code-security/dependabot/working-with-dependabot This is important to get security updates (especially to maintain your Docker images) and then to publish them. Because if you publish Docker images you are now responsible for all these dependencies and Linux stuff in the container to keep it up-to-date.

GitHub Actions is as far as I see not yet used much, but well… easy enough to do that hehe soon…