### PR TITLE
README: Fixup for unmigrated legacy container names

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ ERP beyond your fridge - now containerized!
 
 This repository includes container build infrastructure for [grocy](https://github.com/grocy/grocy).
 
-[![Docker Pulls](https://img.shields.io/docker/pulls/grocy/grocy.svg)](https://hub.docker.com/r/grocy/grocy/)
-[![Docker Stars](https://img.shields.io/docker/stars/grocy/grocy.svg)](https://hub.docker.com/r/grocy/grocy/)
+[![Docker Pulls](https://img.shields.io/docker/pulls/grocy/backend.svg)](https://hub.docker.com/r/grocy/backend/)
+[![Docker Stars](https://img.shields.io/docker/stars/grocy/backend.svg)](https://hub.docker.com/r/grocy/backend/)
 
 ## Prerequisites
 


### PR DESCRIPTION
Relates to / follows-on-from #133.

Resolves #232.