### PR TITLE
Remove IP address from published ports

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     depends_on:
       - backend
     ports:
-      - '127.0.0.1:8080:8080'
+      - '8080:8080'
     read_only: true
     tmpfs:
       - /tmp


### PR DESCRIPTION
The IP address specified in the published ports renders the frontend unreachable from outside of the Docker host. This is inconvenient for deploying the application using a Portainer stack deployed from a git repository.