### PR TITLE
Maintenance: update container images to include Alpine v3.19.1 and Grocy v4.2.0

### DIFF
--- a/Containerfile-backend
+++ b/Containerfile-backend
@@ -1,6 +1,6 @@
 ARG PLATFORM
 
-FROM --platform=${PLATFORM} docker.io/alpine:3.19.0
+FROM --platform=${PLATFORM} docker.io/alpine:3.19.1
 LABEL maintainer "Talmai Oliveira <to@talm.ai>, James Addison <jay@jp-hosting.net>"
 
 ARG GROCY_VERSION

--- a/Containerfile-frontend
+++ b/Containerfile-frontend
@@ -1,6 +1,6 @@
 ARG PLATFORM
 
-FROM --platform=${PLATFORM} docker.io/alpine:3.19.0
+FROM --platform=${PLATFORM} docker.io/alpine:3.19.1
 LABEL maintainer "Talmai Oliveira <to@talm.ai>, James Addison <jay@jp-hosting.net>"
 
 ARG GROCY_VERSION

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: build run pod manifest manifest-create %-backend %-frontend
 
-GROCY_VERSION = v4.0.3
+GROCY_VERSION = v4.2.0
 IMAGE_TAG ?= $(shell git describe --tags --match 'v*' --dirty)
 
 IMAGE_PREFIX ?= docker.io/grocy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,10 +3,10 @@ version: '2.4'
 services:
 
   frontend:
-    image: "grocy/frontend:v4.0.3"
+    image: "grocy/frontend:v4.2.0"
     build:
       args:
-        GROCY_VERSION: v4.0.3
+        GROCY_VERSION: v4.2.0
         PLATFORM: linux/amd64
       context: .
       dockerfile: Containerfile-frontend
@@ -20,10 +20,10 @@ services:
     restart: unless-stopped
 
   backend:
-    image: "grocy/backend:v4.0.3"
+    image: "grocy/backend:v4.2.0"
     build:
       args:
-        GROCY_VERSION: v4.0.3
+        GROCY_VERSION: v4.2.0
         PLATFORM: linux/amd64
       context: .
       dockerfile: Containerfile-backend


### PR DESCRIPTION
It didn't seem straightforward to upgrade the `php82-*` packages to use `php83-*` on Alpine yet; that upgrade is not included here.